### PR TITLE
Some cleanups

### DIFF
--- a/_static/syncthing.css
+++ b/_static/syncthing.css
@@ -1,18 +1,3 @@
-.rst-content p, .rst-content p.admonition-title, .rst-content li, .rst-content table.docutils td,
-.rst-content table.docutils th {
-	font-size: 14pt;
-	line-height: 1.4;
-}
-.rst-content code, .rst-content div[class^='highlight'] pre {
-	font-size: 12pt;
-	line-height: 1.4;
-}
-.rst-content li {
-	margin-bottom: 0.5em;
-}
-.wy-nav-content {
-   max-width: 1050px
-}
 .strike {
 	text-decoration: line-through;
 }

--- a/conf.py
+++ b/conf.py
@@ -15,10 +15,6 @@
 import sys
 import os
 
-import sphinx_rtd_theme
-html_theme = "sphinx_rtd_theme"
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -102,7 +98,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-#html_theme = 'default'
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -133,6 +129,10 @@ pygments_style = 'sphinx'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+# Hack in an additional stylesheet.
+def setup(app):
+    app.add_stylesheet("syncthing.css")
+
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
@@ -140,7 +140,7 @@ html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-#html_last_updated_fmt = '%b %d, %Y'
+html_last_updated_fmt = '%b %d, %Y'
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
@@ -182,6 +182,13 @@ html_static_path = ['_static']
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'Syncthingdoc'
 
+html_context = {
+    'display_github': True,
+    'github_user': 'syncthing',
+    'github_repo': 'docs',
+    'github_version': 'master/',
+    'source_suffix': '.rst',
+}
 
 # -- Options for LaTeX output ---------------------------------------------
 
@@ -260,14 +267,3 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
-
-html_context = {
-'display_github': True,
-'github_user': 'syncthing',
-'github_repo': 'docs',
-'github_version': 'master/',
-'source_suffix': '.rst',
-}
-
-def setup(app):
-   app.add_stylesheet("syncthing.css")


### PR DESCRIPTION
This pr contains two patches:

* Cleanup conf.py
* Remove the font size adjustments

The first one cleans up the config file and reorders the config values. It also enables `html_last_updated_fmt`. The second patch removes the font size adjustments. These adjustments cause several problems, because they only change some little parts of the theme. Those little changes break the overal experience. The commit descriptions contains more details.

```
 _static/syncthing.css | 15 ---------------
 conf.py               | 30 +++++++++++++-----------------
```