### PR TITLE
Added an osx 10.9 compatible client link

### DIFF
--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -48,7 +48,8 @@ Windows
 OS X
 ~~~~
 
--  https://github.com/m0ppers/syncthing-bar
+-  https://github.com/m0ppers/syncthing-bar (OSX 10.10 only)
+-  https://github.com/jerryjacobs/foo-app/releases (OSX 10.9 compatible)
 
 Kindle Touch
 ~~~~~~~~~~~~


### PR DESCRIPTION
added osx 10.9 client link
see https://forum.syncthing.net/t/mac-os-x-native-app-and-disk-image-installer-proof-of-concept/2745