### PR TITLE
reverseproxy: Apache 2.2 is rather old, switch to 2.4

### DIFF
--- a/users/reverseproxy.rst
+++ b/users/reverseproxy.rst
@@ -28,9 +28,8 @@ Apache
 
     ProxyPass /syncthing/ http://localhost:8384/
     <Location /syncthing/>
-      ProxyPassReverse http://localhost:8384/
-      Order Allow,Deny
-      Allow from All
+        ProxyPassReverse http://localhost:8384/
+        Require all granted
     </Location>
 
 Nginx


### PR DESCRIPTION
Apache 2.2 is rather old, IIRC almost debian now ships with 2.4. So
let's document the most recent one.