### PR TITLE
Fix link to Community Contributions from dev/intro

### DIFF
--- a/dev/intro.rst
+++ b/dev/intro.rst
@@ -4,8 +4,7 @@ Syncthing Development
 Controlling Syncthing from External Applications
 ------------------------------------------------
 
-The community has developed a number of `useful applications
-<https://github.com/syncthing/syncthing/wiki/Community-Contributions>`__ that
+People all over the world have developed a number of :ref:`contributions` that
 build around the Syncthing core, such as tray notifications and Android
 support. These are made possible using two APIs:
 


### PR DESCRIPTION
Hi,

Here's a tiny fix for a broken link. This is a blind edit, I didn't check whether it's working for I don't know (yet!) how to build the doc (not documented in the README). I edited the wording as well to avoid duplication of "community" in the final text.