### PR TITLE
Removed metrothing windows client

### DIFF
--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -42,9 +42,6 @@ Windows
    Installer, auto-start, built-in browser, tray icon, folder watcher,
    and more)
 
--  https://github.com/kreischweide/metrothing (Windows UI to monitor
-   multiple Syncthing instances through the REST API)
-
 OS X
 ~~~~
 


### PR DESCRIPTION
Had to deprecate the solution, no more time to maintain it due to job and other constraints.