### PR TITLE
Small fixes to config.rst

### DIFF
--- a/users/config.rst
+++ b/users/config.rst
@@ -152,7 +152,7 @@ device
 versioning
     Specifies a versioning configuration.
 
-    .. note:: Needs explanation.
+    seealso:: :ref:`versioning`
 
 copiers, pullers, hashers
     The number of copier, puller and hasher routines to use, or zero for the
@@ -235,7 +235,7 @@ IPv6 address (``2001:db8::23:42``)
 
 IPv6 address and port (``[2001:db8::23:42]:12345``)
     The address and port is used as given. The address must be enclosed in
-    angled brackets.
+    square brackets.
 
 ``dynamic``
     The word ``dynamic`` means to use local and global discovery to find the
@@ -275,7 +275,7 @@ address
 
     IPv6 address and port (``[::1]:8384``)
         The address and port is used as given. The address must be enclosed in
-        angled brackets.
+        square brackets.
 
     Wildcard and port (``0.0.0.0:12345``, ``[::]:12345``, ``:12345``)
         These are equivalent and will result in Syncthing listening on all

--- a/users/versioning.rst
+++ b/users/versioning.rst
@@ -1,3 +1,4 @@
+.. _versioning:
 File Versioning
 ===============
 


### PR DESCRIPTION
Fixed IPv6 bracket description ([] are square brackets, not angle brackets).  Also added a ref from the versioning object to the page describing versioning options (I'm almost positive the referencing is done correctly... don't have a way to preview it set up).