### PR TITLE
Update ignoring.rst

### DIFF
--- a/users/ignoring.rst
+++ b/users/ignoring.rst
@@ -44,7 +44,7 @@ The ``.stignore`` file contains a list of file or path patterns. The
    ``/foo`` matches ``foo`` but not ``subdir/foo``.
 
 -  A pattern beginning with ``#include`` results in loading patterns
-   from the named file. It is an error for a file to not exist or be
+   from the named file which must reside in the repository. It is an error for a file to not exist or be
    included more than once. Note that while this can be used to include
    patterns from a file in a subdirectory, the patterns themselves are
    still relative to the repository *root*. Example:
@@ -62,7 +62,7 @@ The ``.stignore`` file contains a list of file or path patterns. The
    ``(?i)`` prefix can be combined with other patterns, for example the
    pattern ``(?i)!picture*.png`` indicates that ``Picture1.PNG`` should
    be synchronized. Note that case-insensitive patterns must start with
-   ``(?i)`` when combined with other flags.
+   ``(?i)`` when combined with other flags. On Mac OS and Windows, patterns are always case-insensitive.
 
 -  A line beginning with ``//`` is a comment and has no effect.
 

--- a/users/ignoring.rst
+++ b/users/ignoring.rst
@@ -44,7 +44,7 @@ The ``.stignore`` file contains a list of file or path patterns. The
    ``/foo`` matches ``foo`` but not ``subdir/foo``.
 
 -  A pattern beginning with ``#include`` results in loading patterns
-   from the named file which must reside in the repository. It is an error for a file to not exist or be
+   from the named file. It is an error for a file to not exist or be
    included more than once. Note that while this can be used to include
    patterns from a file in a subdirectory, the patterns themselves are
    still relative to the repository *root*. Example:


### PR DESCRIPTION
Explicitly specify that #include'd files must be within the repo. Note about Mac/Windows always being case-insensitive.