### PR TITLE
Fix StartupComplete event documentation title

### DIFF
--- a/events/startupcomplete.rst
+++ b/events/startupcomplete.rst
@@ -1,4 +1,4 @@
-StartupCompleted
+StartupComplete
 ----------------
 
 Emitted exactly once, when initialization is complete and Syncthing is


### PR DESCRIPTION
Event title is StartupCompleted, while actual event type is StartupComplete (without d). Should be consistent with event type.