### PR TITLE
Update contrib.rst

### DIFF
--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -16,6 +16,7 @@ Cross-platform
 ~~~~~~~~~~~~~~
 
 -  https://github.com/syncthing/syncthing-gtk
+-  https://github.com/sieren/QSyncthingTray
 -  https://github.com/alex2108/syncthing-tray (Tray icon only)
 
 Android
@@ -45,7 +46,6 @@ Windows
 OS X
 ~~~~
 
--  https://github.com/sieren/QSyncthingTray (OSX 10.7+)
 -  https://github.com/m0ppers/syncthing-bar (OSX 10.10 only)
 -  https://github.com/jerryjacobs/foo-app/releases (OSX 10.9 compatible)
 


### PR DESCRIPTION
Updated contributions and moved QSyncthingTray to cross-platform section since it now supports Mac, Windows and Linux.