### PR TITLE
Enable specs manpages

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -279,6 +279,12 @@ man_pages = [
     ('users/faq', 'syncthing-faq',
      'Frequently Asked Questions',
      ['The Syncthing Authors'], 7),
+    ('specs/bep-v1', 'syncthing-bep',
+     'Block Exchange Protocol v1',
+     ['The Syncthing Authors'], 7),
+    ('specs/localdisco-v3', 'syncthing-localdisco',
+     'Local Discovery Protocol v3',
+     ['The Syncthing Authors'], 7),
 ]
 
 # If true, show URL addresses after external links.


### PR DESCRIPTION
It looks really nice:
![screenshot from 2015-09-23 09-26-06](https://cloud.githubusercontent.com/assets/1961699/10039743/62f42f1a-61d5-11e5-8e4d-864ab5baf96f.png)

Is it necessary to include the protocol version in the manpage name, such as `syncthing-bep-v1(7)`? IMO it is enough when the version number is in the automatically generated NAME section: `syncthing-bep - Block Exchange Protocol v1` (it is not in the screenshot, I am too lazy to update the picture. :) )