### PR TITLE
symlink functionality removed

### DIFF
--- a/draft/followsymlinks.rst
+++ b/draft/followsymlinks.rst
@@ -1,14 +1,20 @@
-.. note:: This describes an incomplete feature under development.
+.. note:: This describes a feature that was removed in April 2014.  Syncthing is no longer able to follow symbolic links.
 
-.. warning::
 
-  This is an advanced feature. Be sure to read and fully understand this
-  guide, and have a backup of your data. Incorrect configuration may result in
-  the deletion of your files. Currently it's probably best to only use
-  ``FollowSymlinks`` on a folder master.
+  
+Approximating Symbolic Links
+============================
+
+In Linux, this feature may be approximated by using hard links for individual files, and ``mount --bind`` for directories.  For persistent linked directories, you may add ``bind`` entries to your /etc/fstab.
+  
+
 
 Symbolic Link Following
 =======================
+
+.. warning::
+
+  The ``FollowSymlinks`` setting is no longer functional.
 
 It is possible to synchronize directory trees not present directly under a
 sync folder by using symbolic links ("symlinks") and enabling "following" of


### PR DESCRIPTION
This feature was removed.

https://github.com/syncthing/syncthing/commit/8dee10ba9c46fa86c5b3a808fbe27bbc1b6c83fb

https://github.com/syncthing/syncthing/issues/92#issuecomment-41055432

Example fstab entries and mount commands could also be given - fstab entries are roughly of the form

/directory/to/be/mirrored     /empty/directory/to/mount/to	     bind	    bind,ro,noauto,x-systemd.automount     0 0

``ro`` can be replaced with ``rw`` if you want to give write permissions, ``ro`` is just redundant protection for master directories.  The other options are optional, but delay mounting until it is accessed.

This has been very helpful in my usage of syncthing, I can exclude some subdirectories from syncing while deliberately including others, with everything taking up only one entry in syncthing's GUI instead of many.  

It works just as smoothly as symlinks this way!