### PR TITLE
added HOME variable to fix #72

### DIFF
--- a/users/autostart.rst
+++ b/users/autostart.rst
@@ -158,7 +158,7 @@ Add the following to your ``/etc/supervisord.conf`` file::
     directory = /home/some_user/
     autorestart = True
     user = some_user
-    environment = STNORESTART="1"
+    environment = STNORESTART="1", HOME="home/some_user"
 
 Using systemd
 ~~~~~~~~~~~~~

--- a/users/autostart.rst
+++ b/users/autostart.rst
@@ -158,7 +158,7 @@ Add the following to your ``/etc/supervisord.conf`` file::
     directory = /home/some_user/
     autorestart = True
     user = some_user
-    environment = STNORESTART="1", HOME="home/some_user"
+    environment = STNORESTART="1", HOME="/home/some_user"
 
 Using systemd
 ~~~~~~~~~~~~~


### PR DESCRIPTION
This small change fixes the [configuration for starting with supervisor](http://docs.syncthing.net/users/autostart.html#using-supervisord), so [syncthing won't crash because of the missing HOME variable](https://github.com/syncthing/docs/issues/72). 