### PR TITLE
/rest/system/connections update for v0.12

### DIFF
--- a/rest/system-connections-get.rst
+++ b/rest/system-connections-get.rst
@@ -1,26 +1,56 @@
 GET /rest/system/connections
 ============================
 
-Returns the list of current connections and some metadata associated
-with the connection/peer.
+
+.. note:: Return format changed in 0.12.0.
+
+
+Returns the list of configured devices and some metadata associated
+with them. The list also contains the local device itself as not connected.
 
 .. code-block:: json
 
-    {
-      "connections": {
-        "SMAHWLH-AP74FAB-QWLDYGV-Q65ASPL-GAAR2TB-KEF5FLB-DRLZCPN-DJBFZAG": {
-          "address": "172.21.20.78:22000",
-          "at": "2015-03-16T21:51:38.672758819+01:00",
-          "clientVersion": "v0.10.27",
-          "inBytesTotal": 415980,
-          "outBytesTotal": 396300
-        }
-      },
-      "total": {
-        "address": "",
-        "at": "2015-03-16T21:51:38.672868814+01:00",
-        "clientVersion": "",
-        "inBytesTotal": 415980,
-        "outBytesTotal": 396300
-      }
-    }
+	{
+	   "total" : {
+		  "paused" : false,
+		  "clientVersion" : "",
+		  "at" : "2015-11-07T17:29:47.691637262+01:00",
+		  "connected" : false,
+		  "inBytesTotal" : 1479,
+		  "type" : "direct-accept",
+		  "outBytesTotal" : 1318,
+		  "address" : ""
+	   },
+	   "connections" : {
+		  "YZJBJFX-RDBL7WY-6ZGKJ2D-4MJB4E7-ZATSDUY-LD6Y3L3-MLFUYWE-AEMXJAC" : {
+		     "connected" : true,
+		     "inBytesTotal" : 556,
+		     "paused" : false,
+		     "at" : "2015-11-07T17:29:47.691548971+01:00",
+		     "clientVersion" : "v0.12.1",
+		     "address" : "127.0.0.1:22002",
+		     "type" : "direct-dial",
+		     "outBytesTotal" : 550
+		  },
+		  "DOVII4U-SQEEESM-VZ2CVTC-CJM4YN5-QNV7DCU-5U3ASRL-YVFG6TH-W5DV5AA" : {
+		     "outBytesTotal" : 0,
+		     "type" : "direct-accept",
+		     "address" : "",
+		     "at" : "0001-01-01T00:00:00Z",
+		     "clientVersion" : "",
+		     "paused" : false,
+		     "inBytesTotal" : 0,
+		     "connected" : false
+		  },
+		  "UYGDMA4-TPHOFO5-2VQYDCC-7CWX7XW-INZINQT-LE4B42N-4JUZTSM-IWCSXA4" : {
+		     "address" : "",
+		     "type" : "direct-accept",
+		     "outBytesTotal" : 0,
+		     "connected" : false,
+		     "inBytesTotal" : 0,
+		     "paused" : false,
+		     "at" : "0001-01-01T00:00:00Z",
+		     "clientVersion" : ""
+		  }
+	   }
+	}


### PR DESCRIPTION
Added the output of two remote devices configured: one connected and one disconnected. Maybe the disconnected device could also be left out, but I added it to make clear that disconnected and local device looks the same.