### PR TITLE
Made "https://localhost:8384/" clickable

### DIFF
--- a/intro/getting-started.rst
+++ b/intro/getting-started.rst
@@ -78,7 +78,7 @@ Configuring
 -----------
 
 The admin GUI starts automatically and remains available on
-``https://localhost:8384/``. Cookies are essential to the correct functioning of the GUI; please ensure your browser accepts them. It should look something like this:
+[https://localhost:8384/](https://localhost:8384/). Cookies are essential to the correct functioning of the GUI; please ensure your browser accepts them. It should look something like this:
 
 .. image:: gs1.png
 


### PR DESCRIPTION
It was

    ``https://localhost:8384/''

I know Git's markdown is smart enough to detect urls as normal plaintext. However I don't know if [syncthing.net](http://docs.syncthing.net/intro/getting-started.html) would do the same. So I wrote it as

    [https://localhost:8384/](https://localhost:8384/)