### PR TITLE
Fix formatting and typo on ignoring.rst

### DIFF
--- a/users/ignoring.rst
+++ b/users/ignoring.rst
@@ -64,7 +64,8 @@ The ``.stignore`` file contains a list of file or path patterns. The
    ``(?i)`` prefix can be combined with other patterns, for example the
    pattern ``(?i)!picture*.png`` indicates that ``Picture1.PNG`` should
    be synchronized. Note that case-insensitive patterns must start with
-   ``(?i)`` when combined with other flags. On Mac OS and Windows, patterns are always case-insensitive.
+   ``(?i)`` when combined with other flags. On Mac OS and Windows,
+   patterns are always case-insensitive.
 
 -  A line beginning with ``//`` is a comment and has no effect.
 
@@ -126,14 +127,13 @@ Assume two nodes, Alice and Bob, where Alice has 100 files to share, but
 Bob ignores 25 of these. From Alice's point of view Bob will become
 about 75% in sync (the actual number depends on the sizes of the
 individual files) and remain in "Syncing" state even though it is in
-fact not syncing anything (:issue:`623`). From
-Bob's point of view it's 100% up to date but will show fewer files in
-both the local and global view.
+fact not syncing anything (:issue:`623`). From Bob's point of view, it's
+100% up to date but will show fewer files in both the local and global
+view.
 
 If Bob adds files that have already been synced to the ignore list, they
 will remain in the "global" view but disappear from the "local" view.
 The end result is more files in the global repository than in the local,
-but still 100% in sync (:issue:`624`). From
-Alice's point of view, Bob will remain 100% in sync until the next
-reconnect, because Bob has already announce that he has the files that
-are now suddenly ignored.
+but still 100% in sync (:issue:`624`). From Alice's point of view, Bob
+will remain 100% in sync until the next reconnect, because Bob has
+already announced that he has the files that are now suddenly ignored.


### PR DESCRIPTION
This fixes a typo at the end of the ignoring.rst file and takes the
opportunity to improve the formatting of the RST file a bit and add some
missing commas.