### PR TITLE
Fix sphinx warning

### DIFF
--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -58,7 +58,7 @@ CentOS
 ~~~~~~~~~~~~~~~
 
 -  **UnOfficial packages:**
-https://github.com/mlazarov/syncthing-centos
+   https://github.com/mlazarov/syncthing-centos
 
 ArchLinux
 ~~~~~~~~~


### PR DESCRIPTION
Remove the warning due to a bad identation.