### PR TITLE
Add a link to the official Gentoo package

### DIFF
--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -90,7 +90,7 @@ Docker
 Gentoo
 ~~~~~~
 
-Syncthing is available from the `timboudreau overlay <http://github.com/timboudreau/gentoo>`__ or from `fearedbliss's overlay <https://github.com/fearedbliss/bliss-overlay>`__.
+- https://packages.gentoo.org/packages/net-p2p/syncthing
 
 FreeBSD
 ~~~~~~~


### PR DESCRIPTION
It's been officially part of the Gentoo tree for a while now :)