### PR TITLE
Link to OpenBSD port.

### DIFF
--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -97,6 +97,11 @@ FreeBSD
 
 -  http://www.freshports.org/net/syncthing/
 
+OpenBSD
+~~~~~~~
+
+- http://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/net/syncthing
+
 OpenSUSE
 ~~~~~~~~
 


### PR DESCRIPTION
I just [imported](https://marc.info/?l=openbsd-ports-cvs&m=146126535722830&w=2) Syncthing into OpenBSD ports. Packages will become available for -current soon :)

Can we mention the port in the docs please?

