### PR TITLE
Document lastScan field in /rest/stats/folder API endpoint

### DIFF
--- a/rest/stats-folder-get.rst
+++ b/rest/stats-folder-get.rst
@@ -8,8 +8,8 @@ last scan time and the last synced file.
 
     $ curl -s http://localhost:8384/rest/stats/folder | json
     {
-      "lastScan": "2016-06-02T13:28:01.288181412-04:00",
       "folderid" : {
+        "lastScan": "2016-06-02T13:28:01.288181412-04:00",
         "lastFile" : {
           "filename" : "file/name",
             "at" : "2015-04-16T22:04:18.3066971+01:00"

--- a/rest/stats-folder-get.rst
+++ b/rest/stats-folder-get.rst
@@ -1,13 +1,14 @@
 GET /rest/stats/folder
 ======================
 
-Returns general statistics about folders. Currently, only contains the
-last synced file.
+Returns general statistics about folders. Currently contains the
+last scan time and the last synced file.
 
 .. code-block:: bash
 
     $ curl -s http://localhost:8384/rest/stats/folder | json
     {
+      "lastScan": "2016-06-02T13:28:01.288181412-04:00",
       "folderid" : {
         "lastFile" : {
           "filename" : "file/name",


### PR DESCRIPTION
As per changes proposed in [this PR](https://github.com/syncthing/syncthing/pull/3250).