### PR TITLE
rest/system/ping: Remove obsolete note

### DIFF
--- a/rest/system-ping-post.rst
+++ b/rest/system-ping-post.rst
@@ -2,6 +2,3 @@ POST /rest/system/ping
 ======================
 
 Returns a ``{"ping": "pong"}`` object.
-
-.. note::
-	Due to being a POST request, this method requires using an API key or CSRF token, as opposed to the GET request to the same URL.


### PR DESCRIPTION
A GET request to the /rest/system/ping endpoint also requires an API key or CSRF token.