### PR TITLE
Add missing info on "post 30 days" behavior for staggered versioning

### DIFF
--- a/users/versioning.rst
+++ b/users/versioning.rst
@@ -66,6 +66,8 @@ that will be kept for each.
 30 Days
     For the first 30 days, the most recent version is kept every day.
 Until Maximum Age
+    Until maximum age, the most recent version is kept every week.
+Maximum Age
     The maximum time to keep a version in days. For example, to keep replaced or
     deleted files in the ".stversions" folder for an entire year, use 365. If
     only or 10 days, use 10. **Note: Set to 0 to keep versions forever.**


### PR DESCRIPTION


Add missing versioning behavior info on the behavior after 30 days until maximum age, according to https://github.com/syncthing/syncthing/blob/fa1cfd94d00fbc1b1de8e281cd3ea7afe2c28e24/lib/versioner/staggered.go#L65