### PR TITLE
Explicitly mention blocking behavior

### DIFF
--- a/rest/db-scan-post.rst
+++ b/rest/db-scan-post.rst
@@ -13,6 +13,10 @@ Requesting scan of a path that no longer exists, but previously did, is
 valid and will result in Syncthing noticing the deletion of the path in
 question.
 
+This request blocks until the requested scan is done. This can potentially
+take a long time if a scan or sync is currently in progress for the requested
+folder.
+
 Returns status 200 and no content upon success, or status 500 and a
 plain text error if an error occurred during scanning.
 


### PR DESCRIPTION
As discussed in IRC, it might not be automatically clear that syncthing only returns once the scan has finished. This should make it clear.