### PR TITLE
Update FAQ. Wrong space because line break.

### DIFF
--- a/users/faq.rst
+++ b/users/faq.rst
@@ -171,9 +171,9 @@ What if there is a conflict?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Syncthing does recognize conflicts. When a file has been modified on two devices
-simultaneously, one of the files will be renamed to ``<filename>.sync-
-conflict-<date>-<time>.<ext>``. The device which has the larger value of the
-first 63 bits for his device ID will have his file marked as the conflicting
+simultaneously, one of the files will be renamed to
+``<filename>.sync-conflict-<date>-<time>.<ext>``. The device which has the larger
+value of the first 63 bits for his device ID will have his file marked as the conflicting
 file. Note that we only create ``sync-conflict`` files when the actual content
 differs.
 


### PR DESCRIPTION
Because the line break there was a wrong in"<filename>.sync-␣conflict-<date>-<time>.<ext>". Moved the lines around to avoid this behaviour.