### PR TITLE
Adding convience links to platform-specific documentation.

### DIFF
--- a/users/autostart.rst
+++ b/users/autostart.rst
@@ -4,6 +4,13 @@ Starting Syncthing Automatically
 .. warning::
   This page may be outdated and requires review.
 
+Jump to configuration for your system:
+
+- `Windows <#windows>`__
+- `Mac OS X <#mac-os-x>`__
+- `Linux <#linux>`__
+
+
 Windows
 -------
 


### PR DESCRIPTION
This is a long file with 3 main sections, only one of which is useful for a given user.
Therefore added links to: Windows, Mac and Linux.

Link to the compiled preview: https://build.syncthing.net/docs/104/users/autostart.html