### PR TITLE
Rename "nodes" to "devices" throughout documentation

### DIFF
--- a/dev/debugging.rst
+++ b/dev/debugging.rst
@@ -45,7 +45,7 @@ facilities are something like this:
    discovery system. Debugging here will show which interfaces and
    addresses are selected for broadcasts, etc.
 -  ``discover`` sends and receives local discovery packets. Debugging
-   here will output the parsed packets, nodes that get registered etc.
+   here will output the parsed packets, devices that get registered etc.
 -  ``files`` keeps track of lists of files with metadata and figures out
    which is the newest version of each.
 -  ``net`` shows connection attempts, incoming connections, and the low

--- a/events/localchangedetected.rst
+++ b/events/localchangedetected.rst
@@ -3,7 +3,7 @@ LocalChangeDetected
 
 Generated upon scan whenever the local disk has discovered an updated file from the
 previous scan.  This does NOT include events that are discovered and copied from
-other nodes, only files that were changed on the local filesystem.
+other devices, only files that were changed on the local filesystem.
 
 .. code-block:: json
 

--- a/users/faq.rst
+++ b/users/faq.rst
@@ -154,11 +154,11 @@ Should I keep my device IDs secret?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 No. The IDs are not sensitive. Given a device ID it's possible to find the IP
-address for that node, if global discovery is enabled on it. Knowing the device
-ID doesn't help you actually establish a connection to that node or get a list
+address for that device, if global discovery is enabled on it. Knowing the device
+ID doesn't help you actually establish a connection to that device or get a list
 of files, etc.
 
-For a connection to be established, both nodes need to know about the other's
+For a connection to be established, both devices need to know about the other's
 device ID. It's not possible (in practice) to forge a device ID. (To forge a
 device ID you need to create a TLS certificate with that specific SHA-256 hash.
 If you can do that, you can spoof any TLS certificate. The world is your
@@ -257,8 +257,8 @@ Why is the setup more complicated than BTSync?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Security over convenience. In Syncthing you have to setup both sides to
-connect two nodes. An attacker can't do much with a stolen node ID, because
-you have to add the node on the other side too. You have better control
+connect two devices. An attacker can't do much with a stolen device ID, because
+you have to add the device on the other side too. You have better control
 where your files are transferred.
 
 This is an area that we are working to improve in the long term.

--- a/users/ignoring.rst
+++ b/users/ignoring.rst
@@ -13,11 +13,11 @@ Synopsis
 Description
 -----------
 
-If some files should not be synchronized to other nodes, a file called
+If some files should not be synchronized to other devices, a file called
 ``.stignore`` can be created containing file patterns to ignore. The
 ``.stignore`` file must be placed in the root of the repository. The
-``.stignore`` file itself will never be synced to other nodes, although it can
-``#include`` files that *are* synchronized between nodes. All patterns are
+``.stignore`` file itself will never be synced to other devices, although it can
+``#include`` files that *are* synchronized between devices. All patterns are
 relative to the repository root.
 
 .. note::
@@ -141,7 +141,7 @@ Currently the effects on who is in sync with what can be a bit confusing
 when using ignore patterns. This should be cleared up in a future
 version...
 
-Assume two nodes, Alice and Bob, where Alice has 100 files to share, but
+Assume two devices, Alice and Bob, where Alice has 100 files to share, but
 Bob ignores 25 of these. From Alice's point of view Bob will become
 about 75% in sync (the actual number depends on the sizes of the
 individual files) and remain in "Syncing" state even though it is in

--- a/users/security.rst
+++ b/users/security.rst
@@ -6,9 +6,9 @@ possible for an attacker to join a cluster uninvited, and it should not be
 possible to extract private information from intercepted traffic. Currently this
 is implemented as follows.
 
-All device to device traffic is protected by TLS. To prevent uninvited nodes
-from joining a cluster, the certificate fingerprint of each node is compared
-to a preset list of acceptable nodes at connection establishment. The
+All device to device traffic is protected by TLS. To prevent uninvited devices
+from joining a cluster, the certificate fingerprint of each device is compared
+to a preset list of acceptable devices at connection establishment. The
 fingerprint is computed as the SHA-256 hash of the certificate and displayed
 in BASE32 encoding to form a reasonably compact and convenient string.
 

--- a/users/stdiscosrv.rst
+++ b/users/stdiscosrv.rst
@@ -105,7 +105,7 @@ Configuring
 
 .. note::
    If you are running an instance of syncthing on the discovery server,
-   you must either add that instance to other nodes using a static
+   you must either add that instance to other devices using a static
    address or bind the discovery server and syncthing instances to
    different IP addresses.
 


### PR DESCRIPTION
To match user interface.