### PR TITLE
make.bat: Various minor fixes/improvements

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -4,9 +4,12 @@ REM Command file for Sphinx documentation
 
 if "%SPHINXBUILD%" == "" (
 	set SPHINXBUILD=sphinx-build
+) else (
+	REM Strip quotes from envvar, as we explicitly quote all paths that may have spaces in them.
+	set SPHINXBUILD=%SPHINXBUILD:"=%
 )
 set BUILDDIR=_build
-set ALLSPHINXOPTS=-d %BUILDDIR%/doctrees %SPHINXOPTS% .
+set ALLSPHINXOPTS=-d "%BUILDDIR%\doctrees" %SPHINXOPTS% .
 set I18NSPHINXOPTS=%SPHINXOPTS% .
 if NOT "%PAPER%" == "" (
 	set ALLSPHINXOPTS=-D latex_paper_size=%PAPER% %ALLSPHINXOPTS%
@@ -41,13 +44,13 @@ if "%1" == "help" (
 )
 
 if "%1" == "clean" (
-	for /d %%i in (%BUILDDIR%\*) do rmdir /q /s %%i
-	del /q /s %BUILDDIR%\*
+	for /d %%i in ("%BUILDDIR%\*") do rmdir /q /s "%%i"
+	del /q "%BUILDDIR%\*"
 	goto end
 )
 
 
-%SPHINXBUILD% 2> nul
+"%SPHINXBUILD%" 2>nul >nul
 if errorlevel 9009 (
 	echo.
 	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
@@ -61,31 +64,32 @@ if errorlevel 9009 (
 )
 
 if "%1" == "html" (
-	%SPHINXBUILD% -b html %ALLSPHINXOPTS% %BUILDDIR%/html
+	"%SPHINXBUILD%" -b html %ALLSPHINXOPTS% "%BUILDDIR%\html"
 	if errorlevel 1 exit /b 1
 	echo.
-	echo.Build finished. The HTML pages are in %BUILDDIR%/html.
+	echo.Build finished. The HTML pages are in %BUILDDIR%\html.
 	goto end
 )
 
 if "%1" == "dirhtml" (
-	%SPHINXBUILD% -b dirhtml %ALLSPHINXOPTS% %BUILDDIR%/dirhtml
+	mkdir "%BUILDDIR%\dirhtml"
+	"%SPHINXBUILD%" -b dirhtml %ALLSPHINXOPTS% "%BUILDDIR%\dirhtml"
 	if errorlevel 1 exit /b 1
 	echo.
-	echo.Build finished. The HTML pages are in %BUILDDIR%/dirhtml.
+	echo.Build finished. The HTML pages are in %BUILDDIR%\dirhtml.
 	goto end
 )
 
 if "%1" == "singlehtml" (
-	%SPHINXBUILD% -b singlehtml %ALLSPHINXOPTS% %BUILDDIR%/singlehtml
+	"%SPHINXBUILD%" -b singlehtml %ALLSPHINXOPTS% "%BUILDDIR%\singlehtml"
 	if errorlevel 1 exit /b 1
 	echo.
-	echo.Build finished. The HTML pages are in %BUILDDIR%/singlehtml.
+	echo.Build finished. The HTML pages are in %BUILDDIR%\singlehtml.
 	goto end
 )
 
 if "%1" == "pickle" (
-	%SPHINXBUILD% -b pickle %ALLSPHINXOPTS% %BUILDDIR%/pickle
+	"%SPHINXBUILD%" -b pickle %ALLSPHINXOPTS% "%BUILDDIR%\pickle"
 	if errorlevel 1 exit /b 1
 	echo.
 	echo.Build finished; now you can process the pickle files.
@@ -93,7 +97,7 @@ if "%1" == "pickle" (
 )
 
 if "%1" == "json" (
-	%SPHINXBUILD% -b json %ALLSPHINXOPTS% %BUILDDIR%/json
+	"%SPHINXBUILD%" -b json %ALLSPHINXOPTS% "%BUILDDIR%\json"
 	if errorlevel 1 exit /b 1
 	echo.
 	echo.Build finished; now you can process the JSON files.
@@ -101,28 +105,28 @@ if "%1" == "json" (
 )
 
 if "%1" == "htmlhelp" (
-	%SPHINXBUILD% -b htmlhelp %ALLSPHINXOPTS% %BUILDDIR%/htmlhelp
+	"%SPHINXBUILD%" -b htmlhelp %ALLSPHINXOPTS% "%BUILDDIR%\htmlhelp"
 	if errorlevel 1 exit /b 1
 	echo.
 	echo.Build finished; now you can run HTML Help Workshop with the ^
-.hhp project file in %BUILDDIR%/htmlhelp.
+.hhp project file in %BUILDDIR%\htmlhelp.
 	goto end
 )
 
 if "%1" == "qthelp" (
-	%SPHINXBUILD% -b qthelp %ALLSPHINXOPTS% %BUILDDIR%/qthelp
+	"%SPHINXBUILD%" -b qthelp %ALLSPHINXOPTS% "%BUILDDIR%\qthelp"
 	if errorlevel 1 exit /b 1
 	echo.
 	echo.Build finished; now you can run "qcollectiongenerator" with the ^
-.qhcp project file in %BUILDDIR%/qthelp, like this:
-	echo.^> qcollectiongenerator %BUILDDIR%\qthelp\Syncthing.qhcp
+.qhcp project file in %BUILDDIR%\qthelp, like this:
+	echo.^> qcollectiongenerator "%BUILDDIR%\qthelp\Syncthing.qhcp"
 	echo.To view the help file:
-	echo.^> assistant -collectionFile %BUILDDIR%\qthelp\Syncthing.ghc
+	echo.^> assistant -collectionFile "%BUILDDIR%\qthelp\Syncthing.ghc"
 	goto end
 )
 
 if "%1" == "devhelp" (
-	%SPHINXBUILD% -b devhelp %ALLSPHINXOPTS% %BUILDDIR%/devhelp
+	"%SPHINXBUILD%" -b devhelp %ALLSPHINXOPTS% "%BUILDDIR%\devhelp"
 	if errorlevel 1 exit /b 1
 	echo.
 	echo.Build finished.
@@ -130,113 +134,115 @@ if "%1" == "devhelp" (
 )
 
 if "%1" == "epub" (
-	%SPHINXBUILD% -b epub %ALLSPHINXOPTS% %BUILDDIR%/epub
+	"%SPHINXBUILD%" -b epub %ALLSPHINXOPTS% "%BUILDDIR%\epub"
 	if errorlevel 1 exit /b 1
 	echo.
-	echo.Build finished. The epub file is in %BUILDDIR%/epub.
+	echo.Build finished. The epub file is in %BUILDDIR%\epub.
 	goto end
 )
 
 if "%1" == "latex" (
-	%SPHINXBUILD% -b latex %ALLSPHINXOPTS% %BUILDDIR%/latex
+	"%SPHINXBUILD%" -b latex %ALLSPHINXOPTS% "%BUILDDIR%\latex"
 	if errorlevel 1 exit /b 1
 	echo.
-	echo.Build finished; the LaTeX files are in %BUILDDIR%/latex.
+	echo.Build finished; the LaTeX files are in %BUILDDIR%\latex.
 	goto end
 )
 
 if "%1" == "latexpdf" (
-	%SPHINXBUILD% -b latex %ALLSPHINXOPTS% %BUILDDIR%/latex
-	cd %BUILDDIR%/latex
+	"%SPHINXBUILD%" -b latex %ALLSPHINXOPTS% "%BUILDDIR%\latex"
+	cd "%BUILDDIR%\latex"
 	make all-pdf
-	cd %BUILDDIR%/..
+	cd "%BUILDDIR%\.."
 	echo.
-	echo.Build finished; the PDF files are in %BUILDDIR%/latex.
+	echo.Build finished; the PDF files are in %BUILDDIR%\latex.
 	goto end
 )
 
 if "%1" == "latexpdfja" (
-	%SPHINXBUILD% -b latex %ALLSPHINXOPTS% %BUILDDIR%/latex
-	cd %BUILDDIR%/latex
+	"%SPHINXBUILD%" -b latex %ALLSPHINXOPTS% "%BUILDDIR%\latex"
+	cd "%BUILDDIR%\latex"
 	make all-pdf-ja
-	cd %BUILDDIR%/..
+	cd "%BUILDDIR%\.."
 	echo.
-	echo.Build finished; the PDF files are in %BUILDDIR%/latex.
+	echo.Build finished; the PDF files are in %BUILDDIR%\latex.
 	goto end
 )
 
 if "%1" == "text" (
-	%SPHINXBUILD% -b text %ALLSPHINXOPTS% %BUILDDIR%/text
+	"%SPHINXBUILD%" -b text %ALLSPHINXOPTS% "%BUILDDIR%\text"
 	if errorlevel 1 exit /b 1
 	echo.
-	echo.Build finished. The text files are in %BUILDDIR%/text.
+	echo.Build finished. The text files are in %BUILDDIR%\text.
 	goto end
 )
 
 if "%1" == "man" (
-	%SPHINXBUILD% -b man %ALLSPHINXOPTS% %BUILDDIR%/man
+	"%SPHINXBUILD%" -b man %ALLSPHINXOPTS% "%BUILDDIR%\man"
 	if errorlevel 1 exit /b 1
 	echo.
-	echo.Build finished. The manual pages are in %BUILDDIR%/man.
+	echo.Build finished. The manual pages are in %BUILDDIR%\man.
 	goto end
 )
 
 if "%1" == "texinfo" (
-	%SPHINXBUILD% -b texinfo %ALLSPHINXOPTS% %BUILDDIR%/texinfo
+	"%SPHINXBUILD%" -b texinfo %ALLSPHINXOPTS% "%BUILDDIR%\texinfo"
 	if errorlevel 1 exit /b 1
 	echo.
-	echo.Build finished. The Texinfo files are in %BUILDDIR%/texinfo.
+	echo.Build finished. The Texinfo files are in %BUILDDIR%\texinfo.
 	goto end
 )
 
 if "%1" == "gettext" (
-	%SPHINXBUILD% -b gettext %I18NSPHINXOPTS% %BUILDDIR%/locale
+	"%SPHINXBUILD%" -b gettext %I18NSPHINXOPTS% "%BUILDDIR%\locale"
 	if errorlevel 1 exit /b 1
 	echo.
-	echo.Build finished. The message catalogs are in %BUILDDIR%/locale.
+	echo.Build finished. The message catalogs are in %BUILDDIR%\locale.
 	goto end
 )
 
 if "%1" == "changes" (
-	%SPHINXBUILD% -b changes %ALLSPHINXOPTS% %BUILDDIR%/changes
+	"%SPHINXBUILD%" -b changes %ALLSPHINXOPTS% "%BUILDDIR%\changes"
 	if errorlevel 1 exit /b 1
 	echo.
-	echo.The overview file is in %BUILDDIR%/changes.
+	echo.The overview file is in %BUILDDIR%\changes.
 	goto end
 )
 
 if "%1" == "linkcheck" (
-	%SPHINXBUILD% -b linkcheck %ALLSPHINXOPTS% %BUILDDIR%/linkcheck
+	"%SPHINXBUILD%" -b linkcheck %ALLSPHINXOPTS% "%BUILDDIR%\linkcheck"
 	if errorlevel 1 exit /b 1
 	echo.
 	echo.Link check complete; look for any errors in the above output ^
-or in %BUILDDIR%/linkcheck/output.txt.
+or in %BUILDDIR%\linkcheck\output.txt.
 	goto end
 )
 
 if "%1" == "doctest" (
-	%SPHINXBUILD% -b doctest %ALLSPHINXOPTS% %BUILDDIR%/doctest
+	"%SPHINXBUILD%" -b doctest %ALLSPHINXOPTS% "%BUILDDIR%\doctest"
 	if errorlevel 1 exit /b 1
 	echo.
 	echo.Testing of doctests in the sources finished, look at the ^
-results in %BUILDDIR%/doctest/output.txt.
+results in %BUILDDIR%\doctest\output.txt.
 	goto end
 )
 
 if "%1" == "xml" (
-	%SPHINXBUILD% -b xml %ALLSPHINXOPTS% %BUILDDIR%/xml
+	"%SPHINXBUILD%" -b xml %ALLSPHINXOPTS% "%BUILDDIR%\xml"
 	if errorlevel 1 exit /b 1
 	echo.
-	echo.Build finished. The XML files are in %BUILDDIR%/xml.
+	echo.Build finished. The XML files are in %BUILDDIR%\xml.
 	goto end
 )
 
 if "%1" == "pseudoxml" (
-	%SPHINXBUILD% -b pseudoxml %ALLSPHINXOPTS% %BUILDDIR%/pseudoxml
+	"%SPHINXBUILD%" -b pseudoxml %ALLSPHINXOPTS% "%BUILDDIR%\pseudoxml"
 	if errorlevel 1 exit /b 1
 	echo.
-	echo.Build finished. The pseudo-XML files are in %BUILDDIR%/pseudoxml.
+	echo.Build finished. The pseudo-XML files are in %BUILDDIR%\pseudoxml.
 	goto end
 )
-
+echo Error: "%1" is not a recognised make command.
+echo.
+goto help
 :end


### PR DESCRIPTION
Quoted path given to del, rmdir /s commands. Ouch!
Removed spurious parameter in del command.
dirhtml: Added mkdir for successful build
Initial sphinx-build execute test: correct nul redirection
Forces removal of any quotes around envvars then explicity calls them in
each instance, to ensure they work if spaces are used in paths/vars.
Added error text if no matching arguments passed.
Correct slashes to make them Windowsy.