### PR TITLE
Update Community Contributions

### DIFF
--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -15,36 +15,44 @@ GUI Wrappers
 Cross-platform
 ~~~~~~~~~~~~~~
 
--  https://github.com/syncthing/syncthing-gtk
--  https://github.com/sieren/QSyncthingTray
--  https://github.com/graboluk/stiko
--  https://github.com/Martchus/syncthingtray
+- `Syncthing-GTK <https://github.com/syncthing/syncthing-gtk>`_
+
+- `QSyncthingTray <https://github.com/sieren/QSyncthingTray>`_
+
+- `syncthingtray <https://github.com/Martchus/syncthingtray>`__
+
+- `syncthing-tray <https://github.com/alex2108/syncthing-tray>`_
+
 
 Android
 ~~~~~~~
 
--  https://github.com/syncthing/syncthing-android
+- `syncthing-android <https://github.com/syncthing/syncthing-android>`_
+   A wrapper app for the Syncthing binary.
+
+- `a-sync-browser <https://github.com/davide-imbriaco/a-sync-browser>`_
+   Down- or uploads data from accessible devices, does not continuously keep a
+   share in sync.
 
 .. _contrib-windows:
 
 Windows
 ~~~~~~~
 
--  https://github.com/canton7/SyncTrayzor (Windows host for Syncthing.
-   Installer, auto-start, built-in browser, tray icon, folder watcher,
-   and more)
+- `SyncTrayzor <https://github.com/canton7/SyncTrayzor>`_
+   Windows host for Syncthing.  Installer, auto-start, built-in browser, tray
+   icon, folder watcher, and more.
+
+- `SyncthingTray <https://github.com/iss0/SyncthingTray>`__
+
 
 OS X
 ~~~~
 
--  https://github.com/xor-gate/syncthing-macosx
--  https://github.com/m0ppers/syncthing-bar (OSX 10.10 only)
--  https://github.com/nhojb/SyncthingBar
+- `syncthing-macosx <https://github.com/xor-gate/syncthing-macosx>`_
 
-Kindle Touch
-~~~~~~~~~~~~
+- `SyncthingBar <https://github.com/nhojb/SyncthingBar>`_
 
--  https://github.com/gutenye/syncthing-kindle
 
 Packages and Bundlings
 ----------------------
@@ -52,106 +60,96 @@ Packages and Bundlings
 Debian / Ubuntu
 ~~~~~~~~~~~~~~~
 
--  **Official packages:** https://apt.syncthing.net/
--  Syncthing GTK PPA:
-   https://launchpad.net/~nilarimogard/+archive/ubuntu/webupd8/
+
+- Official packages: https://apt.syncthing.net/
+
+- Debian packages: `syncthing <https://packages.debian.org/search?keywords=>`__, `syncthing-discosrv <https://packages.debian.org/search?keywords=>`__ and `syncthing-relaysrv <https://packages.debian.org/search?keywords=>`_
+
+- `Ubuntu PPA containing Syncthing-GTK <https://launchpad.net/~nilarimogard/+archive/ubuntu/webupd8/>`_
    
 Snap
 ~~~~
 
-On any of the `Linux distributions that support snaps <http://snapcraft.io/docs/core/install>`__:
+On any of the `Linux distributions that support snaps <http://snapcraft.io/docs/core/install>`_: ::
 
    $ snap install syncthing --candidate
    
 (Note that this is an experimental and unstable release, at the moment)
-   
+
 CentOS
 ~~~~~~~~~~~~~~~
 
--  **UnOfficial packages:**
-   https://github.com/mlazarov/syncthing-centos
+Unofficial `RPM package of Syncthing <https://github.com/mlazarov/syncthing-centos>`_
 
 ArchLinux
 ~~~~~~~~~
 
--  https://www.archlinux.org/packages/?name=syncthing
--  https://www.archlinux.org/packages/?name=syncthing-gtk
--  https://www.archlinux.org/packages/?name=syncthing-inotify
--  https://aur.archlinux.org/packages/syncthing-discosrv
+- Official Community Repository: `syncthing <https://www.archlinux.org/packages/?name=syncthing>`__, `syncthing-gtk <https://www.archlinux.org/packages/?name=syncthing-gtk>`__ and `syncthing-inotify <https://www.archlinux.org/packages/?name=syncthing-inotify>`__
+
+- Arch User Repository: `syncthing-discosrv <https://aur.archlinux.org/packages/syncthing-discosrv>`__ and `syncthingtray <https://aur.archlinux.org/packages/syncthingtray>`__
 
 arkOS
 ~~~~~
 
-Syncthing is included in arkOS, https://arkos.io/.
+Syncthing is included in `arkOS <https://arkos.io/>`_.
 
 Docker
 ~~~~~~
 
--  https://github.com/firecat53/dockerfiles/tree/master/syncthing (runs
-   Syncthing and/or builds the binary from source)
--  https://github.com/firecat53/dockerfiles/tree/master/syncthing\_discovery
-   (Global announce server in a container)
--  https://github.com/joeybaker/docker-syncthing/ A fully baked docker
-   container that allows custom config and will keep your settings and
-   data past docker image restarts.
--  https://github.com/djtm/syncthing-docker-scratch (builds docker containers 
-   from scratch base and/or runs the containers in docker or rkt)
--  https://hub.docker.com/r/funkyfuture/rpi-syncthing/ (Configurable image for
-   the Raspberry Pi)
+- `Dockerfiles <https://github.com/firecat53/dockerfiles>`_: `Syncthing <https://github.com/firecat53/dockerfiles/tree/master/syncthing>`__ and `Syncthing Discover Server <https://github.com/firecat53/dockerfiles/tree/master/syncthing\_discovery>`_
+   Runs and/or builds the binaries from source.
 
+- `docker-syncthing <https://github.com/joeybaker/docker-syncthing>`_
+   A fully baked docker container that allows custom config and will keep your
+   settings and data past docker image restarts.
+
+- `syncthing-docker-scratch <https://github.com/djtm/syncthing-docker-scratch>`_
+   Builds docker containers from scratch base and/or runs the containers in
+   docker or rkt.
+
+- `rpi-syncthing <https://github.com/funkyfuture/docker-rpi-syncthing>`_
+   Configurable image for the Raspberry Pi.
 
 Gentoo
 ~~~~~~
 
-- https://packages.gentoo.org/packages/net-p2p/syncthing
+Official net-p2p package: `syncthing <https://packages.gentoo.org/packages/net-p2p/syncthing>`__
 
 FreeBSD
 ~~~~~~~
 
--  http://www.freshports.org/net/syncthing/
+FreshPorts: `syncthing <http://www.freshports.org/net/syncthing>`__
 
 OpenBSD
 ~~~~~~~
 
-- http://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/net/syncthing
+Official ports: `syncthing <http://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/net/syncthing>`__ and `QSyncthingTray <http://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/net/qsyncthingtray>`__
 
 OpenSUSE
 ~~~~~~~~
 
--  http://software.opensuse.org/package/syncthing
--  https://susestudio.com/a/qkdvwb/syncthing
+Official packages: `syncthing <http://software.opensuse.org/package/syncthing>`__ and `syncthingtray <http://software.opensuse.org/package/syncthingtray>`__
 
 Synology NAS (DSM)
 ~~~~~~~~~~~~~~~~~~
 
--  http://packages.synocommunity.com/ Add the URL to Package Center in DSM.
-   (NOTE: This page is not readable in your web browser. You can browse
-   the files at https://synocommunity.com/packages). Numerous CPU
-   architectures are supported. SPK's may be older versions, however you
-   can execute a Syncthing version upgrade via Web-GUI after
-   installation on Synology device.
+Add http://packages.synocommunity.com/ to Package Center in DSM. You find infos
+about the Syncthing package at https://synocommunity.com/packages.  Numerous CPU
+architectures are supported. SPK's may be older versions, however you can
+execute a Syncthing version upgrade via Web-GUI after installation on Synology
+device.
 
 QNAP NAS (QTS)
 ~~~~~~~~~~~~~~
 
--  https://forum.qnap.com/viewtopic.php?f=320&t=97035
-   QPKG (Qnap Package) Available for ALL models x86, x86\_64, Arm (all
-   including new models)
+`Syncthing QPKG <https://forum.qnap.com/viewtopic.php?f=320&t=97035>`__ (Qnap
+Package) available for ALL models x86, x86\_64, Arm (all including new models).
 
 RockStor
 ~~~~~~~~
 
--  Docker Container: http://rockstor.com/docs/docker-based-rock-ons/syncthing.html and registry entry: https://github.com/rockstor/rockon-registry/blob/master/syncthing.json
+`Docker container <http://rockstor.com/docs/docker-based-rock-ons/syncthing.html>`_ and `registry entry <https://github.com/rockstor/rockon-registry/blob/master/syncthing.json>`_
 
-ASUSTOR NAS (ADM)
-~~~~~~~~~~~~~~~~~
-
--  ASUSTOR App Central page: https://www.asustor.com/apps/app_detail?id=552
-
-Windows
-~~~~~~~
-
--  https://github.com/sodacode/Windows-Syncthing-Installer A very minimalist Windows installer.
 
 Integrations
 ------------
@@ -159,22 +157,22 @@ Integrations
 REST API Bindings
 ~~~~~~~~~~~~~~~~~
 
--  Ruby: https://github.com/retgoat/syncthing-ruby
 -  Python: https://github.com/blakev/python-syncthing (https://pypi.python.org/pypi/syncthing)
--  Python: https://github.com/akissa/pysyncthing (https://pypi.python.org/pypi/pysyncthing)
 
 Ports
 ~~~~~
 
--  Swift: https://source.ind.ie/project/pulse-swift/tree/master
+-  Swift: `pulse-swift <https://source.ind.ie/project/pulse-swift/tree/master>`_
+-  Java: `a-sync <https://github.com/davide-imbriaco/a-sync>`_
+    This implements the BEP, discovery and relay protocols providing a command
+    line utility to access a Syncthing network, a service to proxy the relay
+    protocol over http and a client library for the BEP protocol.
 
 Configuration management
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
--  Puppet: https://github.com/whefter/puppet-syncthing
--  Ansible: https://github.com/le9i0nx/ansible-syncthing
--  Salt: https://github.com/ALinuxNinja/salt-syncthing
--  Command line interface: https://github.com/syncthing/syncthing-cli
+-  `puppet-syncthing <https://github.com/whefter/puppet-syncthing>`_
+-  `ansible-syncthing <https://github.com/le9i0nx/ansible-syncthing>`_
 
 Older, Possibly Unmaintained
 ----------------------------
@@ -185,9 +183,17 @@ Older, Possibly Unmaintained
    these and you have revived the project, please update this page
    accordingly.
 
--  https://github.com/alex2108/syncthing-tray
+-  https://github.com/akissa/pysyncthing
+-  https://github.com/retgoat/syncthing-ruby
+-  https://github.com/sodacode/Windows-Syncthing-Installer
+-  https://github.com/gutenye/syncthing-kindle
+-  https://github.com/m0ppers/syncthing-bar (OSX 10.10 only)
+-  https://github.com/graboluk/stiko
+-  https://github.com/ALinuxNinja/salt-syncthing
+-  https://www.asustor.com/apps/app_detail?id=552
+-  https://susestudio.com/a/qkdvwb/syncthing
+-  https://source.ind.ie/project/pulse-swift/tree/master
 -  https://github.com/icaruseffect/syncthing-ubuntu-indicator
--  https://github.com/iss0/SyncthingTray
 -  https://github.com/bloones/SyncThingWin
 -  https://github.com/thunderbirdtr/syncthing_rpm
 -  https://github.com/dapperstout/pulse-java


### PR DESCRIPTION
I moved all projects that haven't been update in the last half year down into the possibly unmaintained section. I also revived some active projects and added new ones.
Then I replaced full links with "linkyfied" project names. I also wanted to drop the dotted lists, but without a short description of the package this looks ugly (too much withespace, almost more than between sections).

Related: Is syncthing/website#51 going to be merged? I think it is really a big improvement as I believe most new user would benefit from Synctrayzor/Syncthing-GTK/...