### PR TITLE
Add an entry about daemonization on Linux

### DIFF
--- a/users/faq.rst
+++ b/users/faq.rst
@@ -437,3 +437,21 @@ GitHub does not provide a single URL to automatically download the latest
 version. We suggest to use the GitHub API at
 https://api.github.com/repos/syncthing/syncthing/releases/latest and parsing
 the JSON response.
+
+
+How do I run Syncthing as a daemon process on Linux?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you're using systemd, runit, or upstart, we already ship examples, check
+https://github.com/syncthing/syncthing/tree/master/etc for example
+configurations.
+
+If however you're not using one of these tools, you have a couple of options.
+If your system has a tool called ``start-stop-daemon`` installed (that's the name
+of the command, not the package), look into the local documentation for that, it
+will almost certainly cover 100% of what you want to do.  If you don't have
+``start-stop-daemon``, there are a bunch of other software packages you could use
+to do this.  The most well known is called daemontools, and can be found in the
+standard package repositories for  almost every modern Linux distribution.
+Other popular tools with similar functionality include S6 and the aforementioned
+runit.


### PR DESCRIPTION
More than 90% of the people who come asking about this are likely to be using a Linux system which doesn't have systemd.  Apparently some such individuals can't do any research beyond Syncthing documentation and the issue tracker, so add an entry to the FAQ to give them some reasonable pointers on what to look at to figure out how to do this on their own without bugging the developers.

Point people at the example configs first, as they may not know they exist (I actually didn't for a few months after I started using Syncthing), then point them at alternatives.

start-stop-daemon is found on a majority of Linux systems these days.  It's practically ABI on Debian derived systems (including Ubuntu), and is a core part of the init system on Gentoo and a handful of other non-systemd distros.  As a result of this and the fact that it's insanely easy to use (and usually very well documented), suggest it first and then point people at less immediately available stuff like daemontools and S6.

Hopefully this should cover the options for most systems, and should also mitigate the number of people asking about how to do this (and when such an issue pops up, whoever answers it can point them here).  The question didn't seem to fit well anywhere specifically, so I just put it at the end of the page.