### PR TITLE
dev/rest: Document /rest/system/browse (fixes #112)

### DIFF
--- a/rest/system-browse-get.rst
+++ b/rest/system-browse-get.rst
@@ -1,0 +1,39 @@
+GET /rest/system/browse
+===================
+
+Returns a list of directories matching the path given by the optional parameter
+``current``. The path can use `patterns as described in go's filepath package
+<https://golang.org/pkg/path/filepath/#Match>`_ and a `*` will be suffixed. It
+is also possible to give a path to a directory to list its contents by adding a
+trailing path separator.
+
+.. code-block:: bash
+
+    $ curl -H "X-API-Key: yourkey" localhost:8384/rest/system/browse | json_pp
+    [
+        "/"
+    ]
+
+    $ curl -H "X-API-Key: yourkey" localhost:8384/rest/system/browse?current=/var/ | json_pp
+    [
+        "/var/backups/",
+        "/var/cache/",
+        "/var/lib/",
+        "/var/local/",
+        "/var/lock/",
+        "/var/log/",
+        "/var/mail/",
+        "/var/opt/",
+        "/var/run/",
+        "/var/spool/",
+        "/var/tmp/"
+    ]
+
+    $ curl -H "X-API-Key: yourkey" localhost:8384/rest/system/browse?current=/var/*o | json_pp
+    [
+        "/var/local/",
+        "/var/lock/",
+        "/var/log/",
+        "/var/opt/",
+        "/var/spool/"
+    ]

--- a/rest/system-browse-get.rst
+++ b/rest/system-browse-get.rst
@@ -2,10 +2,9 @@ GET /rest/system/browse
 ===================
 
 Returns a list of directories matching the path given by the optional parameter
-``current``. The path can use `patterns as described in go's filepath package
-<https://golang.org/pkg/path/filepath/#Match>`_ and a `*` will be suffixed. It
-is also possible to give a path to a directory to list its contents by adding a
-trailing path separator.
+``current``. The path can use `patterns as described in Go's filepath package
+<https://golang.org/pkg/path/filepath/#Match>`_. It is also possible to list a
+directory's contents by adding a trailing path separator.
 
 .. code-block:: bash
 

--- a/rest/system-browse-get.rst
+++ b/rest/system-browse-get.rst
@@ -1,10 +1,11 @@
 GET /rest/system/browse
-===================
+=======================
 
 Returns a list of directories matching the path given by the optional parameter
 ``current``. The path can use `patterns as described in Go's filepath package
-<https://golang.org/pkg/path/filepath/#Match>`_. It is also possible to list a
-directory's contents by adding a trailing path separator.
+<https://golang.org/pkg/path/filepath/#Match>`_. A '*' will always be appended
+to the given path (e.g. ``/tmp/`` matches all its subdirectories). If the option
+``current`` is not given, filesystem root paths are returned.
 
 .. code-block:: bash
 


### PR DESCRIPTION
See #112.
Should there also be a warning about (disk) resource intensity as for [/rest/db/browse](https://docs.syncthing.net/rest/db-browse-get.html)?