### PR TITLE
Add Caddy to reverseproxy.rst

### DIFF
--- a/users/reverseproxy.rst
+++ b/users/reverseproxy.rst
@@ -46,6 +46,21 @@ Nginx
       proxy_pass              http://localhost:8384/;
     }
 
+Caddy
+~~~~~
+
+.. code-block:: nginx
+
+    proxy /syncthing localhost:8384 {
+        transparent
+    }
+    
+    timeouts {
+        read none
+        write none
+        header none
+    }
+
 Folder Configuration
 --------------------
 

--- a/users/reverseproxy.rst
+++ b/users/reverseproxy.rst
@@ -49,12 +49,12 @@ Nginx
 Caddy
 ~~~~~
 
-.. code-block:: nginx
+.. code-block:: none
 
     proxy /syncthing localhost:8384 {
         transparent
     }
-    
+
     timeouts {
         read none
         write none


### PR DESCRIPTION
Small change to add [Caddy](https://caddyserver.com/) in the reverse proxy section.

Caddy is super easy to configure so normally I only have to add the `proxy` block, but with syncthing I had to disable some HTTP timeouts, otherwise it just wouldn't work. With the default timeouts that you can see [here](https://caddyserver.com/docs/timeouts) syncthing would inevitably pop the "Connection Error" popup, and I would see quite a lot of connection errors in my Chrome console.