### PR TITLE
dev/rest: Introducing missing event types (fixes #80)

### DIFF
--- a/dev/events.rst
+++ b/dev/events.rst
@@ -9,13 +9,17 @@ Description
 Syncthing provides a simple long polling interface for exposing events from the
 core utility towards a GUI.
 
-To receive events, perform a HTTP GET of ``/rest/events?since=<lastSeenID>``,
-where ``<lastSeenID>`` is the ID of the last event you've already seen or zero.
-Syncthing returns a JSON encoded array of event objects, starting at the event
-just after the one with the last seen ID. There is a limit to the number of
-events buffered, so if the rate of events is high or the time between polling
-calls is long some events might be missed. This can be detected by noting a
-discontinuity in the event IDs.
+To receive events, perform a HTTP GET of ``/rest/events`` or
+``/rest/events/disk``. The latter returns only :ref:`local-change-detected` and
+:ref:`local-change-detected` events, the former all other events.
+
+The optional parameter ``since=<lastSeenID>`` sets the ID of the last event
+you've already seen. Syncthing returns a JSON encoded array of event objects,
+starting at the event just after the one with this last seen ID. The default
+value is 0, which returns all events. There is a limit to the number of events
+buffered, so if the rate of events is high or the time between polling calls is
+long some events might be missed. This can be detected by noting a discontinuity
+in the event IDs.
 
 If no new events are produced since ``<lastSeenID>``, the HTTP call blocks and
 waits for new events to happen before returning. By default it times out after

--- a/events/downloadprogress.rst
+++ b/events/downloadprogress.rst
@@ -1,3 +1,5 @@
+.. download-progress:
+
 DownloadProgress
 ----------------
 

--- a/events/downloadprogress.rst
+++ b/events/downloadprogress.rst
@@ -1,4 +1,4 @@
-.. download-progress:
+.. _download-progress:
 
 DownloadProgress
 ----------------

--- a/events/folderscanprogress.rst
+++ b/events/folderscanprogress.rst
@@ -1,0 +1,21 @@
+Folder Scan Progress
+--------------------
+
+Emitted in regular intervals (folder setting ProgressIntervalS, 2s by default)
+during scans giving the amount of bytes already scanned and to be scanned in
+total , as well as the current scanning rates in bytes per second.
+
+.. code-block:: json
+
+    {
+       "data" : {
+          "total" : 1,
+          "rate" : 0,
+          "current" : 0,
+          "folder" : "bd7q3-zskm5"
+       },
+       "globalID" : 29,
+       "type" : "FolderScanProgress",
+       "time" : "2017-03-06T15:00:58.072004209+01:00",
+       "id" : 29
+    }

--- a/events/listenaddresseschanged.rst
+++ b/events/listenaddresseschanged.rst
@@ -1,0 +1,54 @@
+.. listen-addresses-changed:
+
+Listen Addresses Changed
+------------------------
+
+This event is emitted when a :ref:`listen address <listen-addresses>` changes.
+
+.. code-block:: json
+
+    {
+       "type" : "ListenAddressesChanged",
+       "id" : 70,
+       "time" : "2017-03-06T15:01:24.88340663+01:00",
+       "globalID" : 70,
+       "data" : {
+          "address" : {
+             "Fragment" : "",
+             "RawQuery" : "",
+             "Scheme" : "dynamic+https",
+             "Path" : "/endpoint",
+             "RawPath" : "",
+             "User" : null,
+             "ForceQuery" : false,
+             "Host" : "relays.syncthing.net",
+             "Opaque" : ""
+          },
+          "wan" : [
+             {
+                "ForceQuery" : false,
+                "User" : null,
+                "Host" : "31.15.66.212:443",
+                "Opaque" : "",
+                "Path" : "/",
+                "RawPath" : "",
+                "RawQuery" : "id=F4HSJVO-CP2C3IL-YLQYLSU-XTYODAG-PPU4LGV-PH3MU4N-G6K56DV-IPN47A&pingInterval=1m0s&networkTimeout=2m0s&sessionLimitBps=0&globalLimitBps=0&statusAddr=:22070&providedBy=",
+                "Scheme" : "relay",
+                "Fragment" : ""
+             }
+          ],
+          "lan" : [
+             {
+                "RawQuery" : "id=F4HSJVO-CP2C3IL-YLQYLSU-XTYODAG-PPU4LGV-PH3MU4N-G6K56DV-IPN47A&pingInterval=1m0s&networkTimeout=2m0s&sessionLimitBps=0&globalLimitBps=0&statusAddr=:22070&providedBy=",
+                "Scheme" : "relay",
+                "Fragment" : "",
+                "RawPath" : "",
+                "Path" : "/",
+                "Host" : "31.15.66.212:443",
+                "Opaque" : "",
+                "ForceQuery" : false,
+                "User" : null
+             }
+          ]
+       }
+    }

--- a/events/localchangedetected.rst
+++ b/events/localchangedetected.rst
@@ -4,8 +4,9 @@ LocalChangeDetected
 -------------------
 
 Generated upon scan whenever the local disk has discovered an updated file from the
-previous scan.  This does NOT include events that are discovered and copied from
-other devices, only files that were changed on the local filesystem.
+previous scan.  This does *not* include events that are discovered and copied from
+other devices (:ref:`remote-change-detected`), only files that were changed on the
+local filesystem.
 
 .. code-block:: json
 

--- a/events/loginattempt.rst
+++ b/events/loginattempt.rst
@@ -1,5 +1,3 @@
-.. login-attempt:
-
 Login Attempt
 -------------
 

--- a/events/loginattempt.rst
+++ b/events/loginattempt.rst
@@ -1,0 +1,21 @@
+.. login-attempt:
+
+Login Attempt
+-------------
+
+When authentication is enable for the GUI, this event is emitted on every
+login attempt. If either the username or password are incorrect, ``success``
+is false and in any case the given username is returned.
+
+.. code-block:: json
+
+    {
+       "id" : 187,
+       "time" : "2017-03-07T00:19:24.420386143+01:00",
+       "data" : {
+          "username" : "somename",
+          "success" : false
+       },
+       "type" : "LoginAttempt",
+       "globalID" : 195
+    }

--- a/events/loginattempt.rst
+++ b/events/loginattempt.rst
@@ -1,7 +1,7 @@
 Login Attempt
 -------------
 
-When authentication is enable for the GUI, this event is emitted on every
+When authentication is enabled for the GUI, this event is emitted on every
 login attempt. If either the username or password are incorrect, ``success``
 is false and in any case the given username is returned.
 

--- a/events/remotechangedetected.rst
+++ b/events/remotechangedetected.rst
@@ -1,0 +1,24 @@
+.. remote-change-detected:
+
+RemoteChangeDetected
+-------------------
+
+Generated upon scan whenever a file is locally updated due to a remote change.
+Files that were updated locally produce a :ref:`local-change-detected` event.
+
+.. code-block:: json
+
+   {
+      "time" : "2017-03-06T23:58:21.844739891+01:00",
+      "globalID" : 123,
+      "data" : {
+         "type" : "file",
+         "action" : "deleted",
+         "path" : "/media/ntfs_data/Dokumente/testfile",
+         "label" : "Dokumente",
+         "folderID" : "Dokumente",
+         "modifiedBy" : "BPDFDTU"
+      },
+      "type" : "RemoteChangeDetected",
+      "id" : 2
+   }

--- a/events/remotechangedetected.rst
+++ b/events/remotechangedetected.rst
@@ -1,4 +1,4 @@
-.. remote-change-detected:
+.. _remote-change-detected:
 
 RemoteChangeDetected
 -------------------

--- a/events/remotechangedetected.rst
+++ b/events/remotechangedetected.rst
@@ -4,7 +4,7 @@ RemoteChangeDetected
 -------------------
 
 Generated upon scan whenever a file is locally updated due to a remote change.
-Files that were updated locally produce a :ref:`local-change-detected` event.
+Files that are updated locally produce a :ref:`local-change-detected` event.
 
 .. code-block:: json
 

--- a/events/remotechangedetected.rst
+++ b/events/remotechangedetected.rst
@@ -1,7 +1,7 @@
 .. _remote-change-detected:
 
 RemoteChangeDetected
--------------------
+--------------------
 
 Generated upon scan whenever a file is locally updated due to a remote change.
 Files that are updated locally produce a :ref:`local-change-detected` event.

--- a/events/remotedownloadprogress.rst
+++ b/events/remotedownloadprogress.rst
@@ -3,10 +3,10 @@
 Remote Download Progress
 ------------------------
 
-This event is emitted when a :ref:`DownloadProgress` message is
+This event is emitted when a :ref:`download-progress` message is
 received. It returns the map ``data`` of filenames to count of
 downloaded blocks. The files in questions are currently being
-downloaded on the remote ``device`` and belong to ``folder``. 
+downloaded on the remote ``device`` and belong to ``folder``.
 
 .. code-block:: json
 

--- a/events/remotedownloadprogress.rst
+++ b/events/remotedownloadprogress.rst
@@ -2,7 +2,7 @@ Remote Download Progress
 ------------------------
 
 This event is emitted when a :ref:`download-progress` message is
-received. It returns the map ``data`` of filenames to count of
+received. It returns a map ``data`` of filenames with a count of
 downloaded blocks. The files in questions are currently being
 downloaded on the remote ``device`` and belong to ``folder``.
 

--- a/events/remotedownloadprogress.rst
+++ b/events/remotedownloadprogress.rst
@@ -1,0 +1,25 @@
+.. remote-download-progress:
+
+Remote Download Progress
+------------------------
+
+This event is emitted when a :ref:`DownloadProgress` message is
+received. It returns the map ``data`` of filenames to count of
+downloaded blocks. The files in questions are currently being
+downloaded on the remote ``device`` and belong to ``folder``. 
+
+.. code-block:: json
+
+    {
+       "time" : "2017-03-07T00:11:37.65838955+01:00",
+       "globalID" : 170,
+       "data" : {
+          "state" : {
+             "tahr64-6.0.5.iso" : 1784
+          },
+          "device" : "F4HSJVO-CP2C3IL-YLQYLSU-XTYODAG-PPU4LGV-PH3MU4N-G6K56DV-IPN47A",
+          "folder" : "Dokumente"
+       },
+       "type" : "RemoteDownloadProgress",
+       "id" : 163
+    }

--- a/events/remotedownloadprogress.rst
+++ b/events/remotedownloadprogress.rst
@@ -1,5 +1,3 @@
-.. remote-download-progress:
-
 Remote Download Progress
 ------------------------
 

--- a/rest/events-disk-get.rst
+++ b/rest/events-disk-get.rst
@@ -3,11 +3,11 @@ GET /rest/events/disk
 
 Returns local disk events that occur when the scanner detects local file system
 changes (:ref:`local-change-detected`) or when files are pulled from a remote
-device. In addition it returns :ref:`ping` events, such that this request
-returns after a minute, at the latest.
+device (:ref:`remote-change-detected`).
 
 Optional GET parameters:
  - since (events starting after the given ID)
+ - timeout (fail after given seconds if no event is available, 2s by default)
  - limit (return last x number of events)
 
 .. code-block:: bash

--- a/users/config.rst
+++ b/users/config.rst
@@ -446,7 +446,7 @@ The ``options`` element contains all other global configuration options.
 
 listenAddress
     The listen address for incoming sync connections. See
-    `Listen Addresses`_ for allowed syntax.
+    :ref:`listen-addresses` for allowed syntax.
 
 globalAnnounceServer
     A URI to a global announce (discovery) server, or the word ``default`` to
@@ -582,6 +582,8 @@ overwriteRemoteDeviceNamesOnConnect
 tempIndexMinBlocks
     When exchanging index information for incomplete transfers, only take
     into account files that have at least this many blocks.
+
+.. _listen-addresses:
 
 Listen Addresses
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Update event documentation: Specify since as optional, as it actually is in the code and is also used thus for the web GUI and add missing events.