### PR TITLE
Remove the candidate warning about the snap

### DIFF
--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -79,9 +79,9 @@ On any of the `Linux distributions that support snaps <https://snapcraft.io/docs
 
    $ snap install syncthing
 
-If you want to help testing the upcoming release, you can install the snap from the candidate channel:
+If you want to help testing the upcoming release, and get the newer features earlier, you can install the snap from the candidate channel:
 
-   $ snap install syncting --candidate
+   $ snap install syncthing --candidate
 
 CentOS
 ~~~~~~~~~~~~~~~

--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -77,9 +77,7 @@ Snap
 
 On any of the `Linux distributions that support snaps <https://snapcraft.io/docs/core/install>`_: ::
 
-   $ snap install syncthing --candidate
-   
-(Note that this is an experimental and unstable release, at the moment)
+   $ snap install syncthing
 
 CentOS
 ~~~~~~~~~~~~~~~

--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -79,6 +79,10 @@ On any of the `Linux distributions that support snaps <https://snapcraft.io/docs
 
    $ snap install syncthing
 
+If you want to help testing the upcoming release, you can install the snap from the candidate channel:
+
+   $ snap install syncting --candidate
+
 CentOS
 ~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
I've been using the stable snap for a while without any issues, with updates and everything. I think it's safe now to recommend people to install the stable channel.