### PR TITLE
Depend on built-in Go environment variables

### DIFF
--- a/dev/building.rst
+++ b/dev/building.rst
@@ -47,18 +47,16 @@ Building (Unix)
     # This should output "go version go1.8" or higher.
     $ go version
 
-    # Go is particular about file locations; use this path unless you know very
-    # well what you're doing.
-    $ mkdir -p ~/src/github.com/syncthing
-    $ cd ~/src/github.com/syncthing
-    # Note that if you are building from a source code archive, you need to
-    # rename the directory from syncthing-XX.YY.ZZ to syncthing
-    $ git clone https://github.com/syncthing/syncthing
+    # If you are building from a source code archive you can skip the
+    # next step, all you need to do is extract all the files to 
+    # $GOPATH/src/github.com/syncthing/syncthing
+
+    $ go get github.com/syncthing/syncthing
+    # Ignore the warning about no buildable Go src files, we'll build them
+    # manually.
 
     # Now we have the source. Time to build!
-    $ cd syncthing
-
-    # You should be inside ~/src/github.com/syncthing/syncthing right now.
+    $ cd $GOPATH/src/github.com/syncthing/syncthing
     $ go run build.go
 
 Unless something goes wrong, you will have a ``syncthing`` binary built
@@ -73,16 +71,16 @@ Building (Windows)
     # This should output "go version go1.8" or higher.
     > go version
 
-    # Go is particular about file locations; use this path unless you know very
-    # well what you're doing.
-    > mkdir c:\src\github.com\syncthing
-    > cd c:\src\github.com\syncthing
-    # Note that if you are building from a source code archive, you need to
-    # rename the directory from syncthing-XX.YY.ZZ to syncthing
-    > git clone https://github.com/syncthing/syncthing
+    # If you are building from a source code archive you can skip the
+    # next step, all you need to do is extract all the files to 
+    # %GOPATH%\src\github.com\syncthing\syncthing
+
+    > go get github.com/syncthing/syncthing
+    # Ignore the warning about no buildable Go src files, we'll build them
+    # manually.
 
     # Now we have the source. Time to build!
-    > cd syncthing
+    > cd %GOPATH%\src\github.com\syncthing\syncthing
     > go run build.go
 
 Unless something goes wrong, you will have a ``syncthing.exe`` binary

--- a/dev/building.rst
+++ b/dev/building.rst
@@ -60,7 +60,7 @@ Building (Unix)
     $ go run build.go
 
 Unless something goes wrong, you will have a ``syncthing`` binary built
-and ready in ``~/src/github.com/syncthing/syncthing/bin``.
+and ready in ``$GOPATH/src/github.com/syncthing/syncthing/bin``.
 
 Building (Windows)
 ------------------
@@ -84,7 +84,7 @@ Building (Windows)
     > go run build.go
 
 Unless something goes wrong, you will have a ``syncthing.exe`` binary
-built and ready in ``c:\src\github.com\syncthing\syncthing\bin``.
+built and ready in ``%GOPATH%\src\github.com\syncthing\syncthing\bin``.
 
 Subcommands and Options
 -----------------------


### PR DESCRIPTION
Users may have set up their Go installation in a different folder (also Go's site suggests a default of `~/go/` for the GOPATH instead of just `~/`) so use Go's built-in environment variables for building.

Secondly, Go's `get` command automatically takes care of setting up the correct directories and calls Git to clone the repository. It just simplifies the procedure slightly.