### PR TITLE
Add gnome extension to user contribs

### DIFF
--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -59,6 +59,13 @@ Mac OS
 
 - `BitBar plugin <https://github.com/sebw/bitbar-plugins>`_
 
+Linux
+~~~~~
+
+- `Syncthing Icon <https://extensions.gnome.org/extension/989/syncthing-icon/>`_
+
+  A GNOME Shell extension displaying a Syncthing status icon in the top bar.
+
 Packages and Bundlings
 ----------------------
 


### PR DESCRIPTION
I was looking for something like this and was wondering why it's not mentioned in the contributions list.
I'm not the author, @jaystrictor is it ok to add it here?