### PR TITLE
Fix an error in the Request id description

### DIFF
--- a/specs/bep-v1.rst
+++ b/specs/bep-v1.rst
@@ -499,7 +499,7 @@ Fields
 ~~~~~~
 
 The **id** is the request identifier. It will be matched in the
-corresponding **Request** message. Each outstanding request must have a
+corresponding **Response** message. Each outstanding request must have a
 unique ID.
 
 The **folder** and **name** fields are as documented for the Index message.


### PR DESCRIPTION
The id field in the Request message will be matched with the id field in the Response message, not itself.