### PR TITLE
added serl/syncthing-quick-status

### DIFF
--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -66,6 +66,10 @@ Linux
 
   A GNOME Shell extension displaying a Syncthing status icon in the top bar.
 
+- `syncthing-quick-status <https://github.com/serl/syncthing-quick-status>`_
+
+  Small bash application with minimal dependecies, for a simple colorful representation of the current status.
+
 Packages and Bundlings
 ----------------------
 


### PR DESCRIPTION
Howdy!

While fiddling around a bit yesterday, I did this simple script to have the current status in a glance without opening the browser (i.e. from a ssh session).

Comments much appreciated!