### PR TITLE
Be explicit that symlinks are not followed

### DIFF
--- a/users/faq.rst
+++ b/users/faq.rst
@@ -56,7 +56,7 @@ The following may be synchronized or not, depending:
 
 -  File Permissions (When supported by file system. On Windows, only the
    read only bit is synchronized.)
--  Symbolic Links (Except on Windows.)
+-  Symbolic Links (synced, except on Windows, but never followed.)
 
 The following are *not* synchronized;
 


### PR DESCRIPTION
Listing symlinks under things that are "synced" can cause confusion about about what is actually copied over: the link itself or the contents of the linked file. Indicating that symlinks are synced but not followed clarifies this situation and parallels the language used for Hard Links below.