### PR TITLE
And KCP listener documentation with static relay

### DIFF
--- a/users/config.rst
+++ b/users/config.rst
@@ -739,10 +739,16 @@ TCP IPv6 wildcard and port (``tcp6://[::]:22000``, ``tcp6://:22000``)
 TCP IPv6 address and port (``tcp6://[2001:db8::42]:22000``)
     This results in Syncthing listening on the specified address and port, IPv6
     only.
+    
+KCP listener address (``kcp://0.0.0.0:22000``, ``kcp://:22020``)
+    Syncthing will connect to and listen for incoming connections via the KCP protocol on IPv6 and IPv6.
 
 Static relay address (``relay://192.0.2.42:22067?id=abcd123...``)
     Syncthing will connect to and listen for incoming connections via the
     specified relay address.
+   
+Static relay address with KCP and TCP (``kcp://:22020, relay://your.server.com:22067/?id=abcd123..., tcp://:22000``)
+    Syncthing will utilise KCP and TCP listening along with a private relay as fall back option.
 
     .. todo:: Document available URL parameters.
 


### PR DESCRIPTION
Existing documentation talks about how to use a private relay but it is not clear that in doing it that way it then removes the TCP and KCP listeners, resulting in poor performance on local LAN segments etc. This commit attempts to clarify that.