### PR TITLE
users/faq: Add entry about increasing inotify watches

### DIFF
--- a/users/faq.rst
+++ b/users/faq.rst
@@ -515,10 +515,10 @@ On many Linux distributions you can run the following to fix it::
     echo "fs.inotify.max_user_watches=204800" | sudo tee -a /etc/sysctl.conf
 
 On Arch Linux and potentially others it is preferred to write this line into a
-separate file, i.e., you should run::
+separate file, i.e. you should run::
 
     echo "fs.inotify.max_user_watches=204800" | sudo tee -a /etc/sysctl.d/90-override.conf
 
-This only takes effect after a reboot. To adjust the limit immediately, run ::
+This only takes effect after a reboot. To adjust the limit immediately, run::
 
     sudo sh -c 'echo 204800 > /proc/sys/fs/inotify/max_user_watches'

--- a/users/faq.rst
+++ b/users/faq.rst
@@ -497,25 +497,25 @@ runit.
 
 .. _inotify-limits:
 
-How do I increase the inotify limit to get my fs watcher to work?
------------------------------------------------------------------
+How do I increase the inotify limit to get my filesystem watcher to work?
+-------------------------------------------------------------------------
 
 You are probably reading this because you encountered the following error with
-the fs watcher on linux:
+the filesystem watcher on linux:
 
     Failed to start filesystem watcher for folder yourLabel (yourID): failed to
     setup inotify handler. Please increase inotify limits, see
     https://docs.syncthing.net/users/faq.html#inotify-limits
 
-Linux typically restricts the amount of watches per user (usually 8192). So if
-you have a more directories, you need to adjust that number.
+Linux typically restricts the amount of watches per user (usually 8192). When
+you have more directories you need to adjust that number.
 
-On many Linux distributions you can run the following to fix it: ::
+On many Linux distributions you can run the following to fix it::
 
     echo "fs.inotify.max_user_watches=204800" | sudo tee -a /etc/sysctl.conf
 
 On Arch Linux and potentially others it is preferred to write this line into a
-separate file, i.e. you should run ::
+separate file, i.e., you should run::
 
     echo "fs.inotify.max_user_watches=204800" | sudo tee -a /etc/sysctl.d/90-override.conf
 

--- a/users/faq.rst
+++ b/users/faq.rst
@@ -494,3 +494,31 @@ to do this.  The most well known is called daemontools, and can be found in the
 standard package repositories for  almost every modern Linux distribution.
 Other popular tools with similar functionality include S6 and the aforementioned
 runit.
+
+.. _inotify-limits:
+
+How do I increase the inotify limit to get my fs watcher to work?
+-----------------------------------------------------------------
+
+You are probably reading this because you encountered the following error with
+the fs watcher on linux:
+
+    Failed to start filesystem watcher for folder yourLabel (yourID): failed to
+    setup inotify handler. Please increase inotify limits, see
+    https://docs.syncthing.net/users/faq.html#inotify-limits
+
+Linux typically restricts the amount of watches per user (usually 8192). So if
+you have a more directories, you need to adjust that number.
+
+On many Linux distributions you can run the following to fix it: ::
+
+    echo "fs.inotify.max_user_watches=204800" | sudo tee -a /etc/sysctl.conf
+
+On Arch Linux and potentially others it is preferred to write this line into a
+separate file, i.e. you should run ::
+
+    echo "fs.inotify.max_user_watches=204800" | sudo tee -a /etc/sysctl.d/90-override.conf
+
+This only takes effect after a reboot. To adjust the limit immediately, run ::
+
+    sudo sh -c 'echo 204800 > /proc/sys/fs/inotify/max_user_watches'


### PR DESCRIPTION
This integrates https://github.com/syncthing/syncthing-inotify/#troubleshooting-for-folders-with-many-files-on-linux into our own documentation to be linked to in the appropriate error message (syncthing/syncthing#4833).