### PR TITLE
events: Add missing name property for DeviceRejected

### DIFF
--- a/events/devicerejected.rst
+++ b/events/devicerejected.rst
@@ -12,6 +12,7 @@ to talk to.
         "time": "2014-08-19T10:43:00.562821045+02:00",
         "data": {
             "address": "127.0.0.1:51807",
+            "name" : "My dusty computer",
             "device": "EJHMPAQ-OGCVORE-ISB4IS3-SYYVJXF-TKJGLTU-66DIQPF-GJ5D2GX-GQ3OWQK"
         }
     }


### PR DESCRIPTION
It seems the documentation was missing a property for the DeviceRejected event which is implemented here https://github.com/syncthing/syncthing/blob/7b0d8c2e77750caa335aa3216dffcff4ffeb0115/lib/model/model.go#L1524.