### PR TITLE
events: Add globalID to all json samples

### DIFF
--- a/events/configsaved.rst
+++ b/events/configsaved.rst
@@ -8,6 +8,7 @@ itself.
 
     {
         "id": 50,
+        "globalID": 50,
         "type": "ConfigSaved",
         "time": "2014-12-13T00:09:13.5166486Z",
         "data": {

--- a/events/deviceconnected.rst
+++ b/events/deviceconnected.rst
@@ -7,6 +7,7 @@ Generated each time a connection to a device has been established.
 
     {
         "id": 2,
+        "globalID": 2,
         "type": "DeviceConnected",
         "time": "2014-07-13T21:04:33.687836696+02:00",
         "data": {

--- a/events/devicedisconnected.rst
+++ b/events/devicedisconnected.rst
@@ -7,6 +7,7 @@ Generated each time a connection to a device has been terminated.
 
     {
         "id": 48,
+        "globalID": 48,
         "type": "DeviceDisconnected",
         "time": "2014-07-13T21:18:52.859929215+02:00",
         "data": {

--- a/events/devicediscovered.rst
+++ b/events/devicediscovered.rst
@@ -7,6 +7,7 @@ Emitted when a new device is discovered using local discovery.
 
     {
         "id": 13,
+        "globalID": 13,
         "type": "DeviceDiscovered",
         "time": "2014-07-17T13:28:05.043465207+02:00",
         "data": {

--- a/events/devicepaused.rst
+++ b/events/devicepaused.rst
@@ -7,6 +7,7 @@ Emitted when a device was paused.
 
     {
         "id": 13,
+        "globalID": 13,
         "type": "DevicePaused",
         "time": "2014-07-17T13:28:05.043465207+02:00",
         "data": {

--- a/events/devicerejected.rst
+++ b/events/devicerejected.rst
@@ -8,6 +8,7 @@ to talk to.
 
     {
         "id": 24,
+        "globalID": 24,
         "type": "DeviceRejected",
         "time": "2014-08-19T10:43:00.562821045+02:00",
         "data": {

--- a/events/deviceresumed.rst
+++ b/events/deviceresumed.rst
@@ -7,6 +7,7 @@ Generated each time a device was resumed.
 
     {
         "id": 2,
+        "globalID": 2,
         "type": "DeviceResumed",
         "time": "2014-07-13T21:04:33.687836696+02:00",
         "data": {

--- a/events/downloadprogress.rst
+++ b/events/downloadprogress.rst
@@ -11,6 +11,7 @@ configuration can cause multiple files to be shown.
 
     {
         "id": 221,
+        "globalID": 221,
         "type": "DownloadProgress",
         "time": "2014-12-13T00:26:12.9876937Z",
         "data": {

--- a/events/foldercompletion.rst
+++ b/events/foldercompletion.rst
@@ -10,6 +10,7 @@ device.
 
     {
         "id": 84,
+        "globalID": 84,
         "type": "FolderCompletion",
         "time": "2015-04-17T14:14:27.043576583+09:00",
         "data": {

--- a/events/folderrejected.rst
+++ b/events/folderrejected.rst
@@ -8,6 +8,7 @@ have, or have but do not share with the device in question.
 
     {
         "id": 27,
+        "globalID": 27,
         "type": "FolderRejected",
         "time": "2014-08-19T10:41:06.761751399+02:00",
         "data": {

--- a/events/foldersummary.rst
+++ b/events/foldersummary.rst
@@ -9,6 +9,7 @@ state.
 
     {
         "id": 16,
+        "globalID": 16,
         "type": "FolderSummary",
         "time": "2015-04-17T14:12:20.460121585+09:00",
         "data": {

--- a/events/itemfinished.rst
+++ b/events/itemfinished.rst
@@ -8,6 +8,7 @@ successful operation:
 
     {
         "id": 93,
+        "globalID": 93,
         "type": "ItemFinished",
         "time": "2014-07-13T21:22:03.414609034+02:00",
         "data": {
@@ -25,6 +26,7 @@ An unsuccessful operation:
 
     {
         "id": 44,
+        "globalID": 44,
         "type": "ItemFinished",
         "time": "2015-05-27T11:21:05.711133004+02:00",
         "data": {

--- a/events/itemstarted.rst
+++ b/events/itemstarted.rst
@@ -7,6 +7,7 @@ Generated when Syncthing begins synchronizing a file to a newer version.
 
     {
         "id": 93,
+        "globalID": 93,
         "type": "ItemStarted",
         "time": "2014-07-13T21:22:03.414609034+02:00",
         "data": {

--- a/events/localindexupdated.rst
+++ b/events/localindexupdated.rst
@@ -9,6 +9,7 @@ changes during a scan.
 
     {
         "id": 59,
+        "globalID": 59,
         "type": "LocalIndexUpdated",
         "time": "2014-07-17T13:27:28.051369434+02:00",
         "data": {

--- a/events/remoteindexupdated.rst
+++ b/events/remoteindexupdated.rst
@@ -7,6 +7,7 @@ Generated each time new index information is received from a device.
 
     {
         "id": 44,
+        "globalID": 44,
         "type": "RemoteIndexUpdated",
         "time": "2014-07-13T21:04:35.394184435+02:00",
         "data": {

--- a/events/starting.rst
+++ b/events/starting.rst
@@ -8,6 +8,7 @@ configuration etc.
 
     {
         "id": 1,
+        "globalID": 1,
         "type": "Starting",
         "time": "2014-07-17T13:13:32.044470055+02:00",
         "data": {

--- a/events/startupcomplete.rst
+++ b/events/startupcomplete.rst
@@ -8,6 +8,7 @@ ready to start exchanging data with other devices.
 
     {
         "id": 1,
+        "globalID": 1,
         "type": "StartupComplete",
         "time": "2014-07-13T21:03:18.383239179+02:00",
         "data": null

--- a/events/statechanged.rst
+++ b/events/statechanged.rst
@@ -13,6 +13,7 @@ seconds and is now in state ``idle``.
 
     {
         "id": 8,
+        "globalID": 8,
         "type": "StateChanged",
         "time": "2014-07-17T13:14:28.697493016+02:00",
         "data": {


### PR DESCRIPTION
Due to https://forum.syncthing.net/t/event-api-seems-not-blocking/11818/3

I didn't look at anything manually, just scripted in `globalID` with the same value as `id` if necessary.