### PR TITLE
users/contrib.rst: Remove reference to syncthing-macosx

### DIFF
--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -53,8 +53,6 @@ Windows
 Mac OS
 ~~~~~~ 
 
-- `syncthing-macosx <https://github.com/xor-gate/syncthing-macosx>`_
-
 - `SyncthingBar <https://github.com/nhojb/SyncthingBar>`_
 
 - `BitBar plugin <https://github.com/sebw/bitbar-plugins>`_


### PR DESCRIPTION
xor-gate/syncthing-macosx moved from xor-gate to syncthing github org