### PR TITLE
doc update: default is not HTTPS

### DIFF
--- a/intro/getting-started.rst
+++ b/intro/getting-started.rst
@@ -78,7 +78,7 @@ Configuring
 -----------
 
 The admin GUI starts automatically and remains available on
-``https://localhost:8384/``. Cookies are essential to the correct functioning of the GUI; please ensure your browser accepts them. It should look something like this:
+``http://localhost:8384/``. Cookies are essential to the correct functioning of the GUI; please ensure your browser accepts them. It should look something like this:
 
 .. image:: gs1.png
 


### PR DESCRIPTION
When installing syncthing for the very first time, the GUI is not starting on SSL. This adjusts the Getting Started chapter accordingly.