### PR TITLE
Update Syncthing-Android maintainers

### DIFF
--- a/intro/project-presentation.rst
+++ b/intro/project-presentation.rst
@@ -22,7 +22,6 @@ syncthing-android
 `syncthing-android`_ is the Android packaging and native UI on top of
 Syncthing.
 
--  Catfriend1 / :user:`Catfriend1`
 -  Audrius Butkevicius / :user:`AudriusButkevicius`
 
 Syncthing-GTK

--- a/intro/project-presentation.rst
+++ b/intro/project-presentation.rst
@@ -22,8 +22,8 @@ syncthing-android
 `syncthing-android`_ is the Android packaging and native UI on top of
 Syncthing.
 
--  Felix Ableitner / :user:`Nutomic`
--  Lode Hoste / :user:`Zillode`
+-  Catfriend1 / :user:`Catfriend1`
+-  Audrius Butkevicius / :user:`AudriusButkevicius`
 
 Syncthing-GTK
 -------------


### PR DESCRIPTION
I just noticed that the list of maintainers was out of date, as I am currently not active as maintainer, and afaik Zillode hasn't done anything on the project in quite a while.

@Catfriend1 I didn't see a name on your profile, so I assume you want to be pseudonymous.

By the way, you might want to add other projects that are linked from the website, like SyncTrayzor or syncthing-macos.