### PR TITLE
Add note with example about IP + 'dynamic' combo

### DIFF
--- a/users/config.rst
+++ b/users/config.rst
@@ -431,6 +431,17 @@ address
         The word ``dynamic`` (without ``tcp://`` prefix) means to use local and
         global discovery to find the device.
 
+    You can set multiple addresses *and* combine it with the ``dynamic`` keyword
+    for example:
+
+    .. code-block:: xml
+
+        <device id="...">
+            <address>tcp://192.0.2.1:22001</address>
+            <address>tcp://192.0.1.254:22000</address>
+            <address>dynamic</address>
+        </device>
+
 paused
     True if synchronization with this devices is (temporarily) suspended.
 


### PR DESCRIPTION
I was wondering whether I can actually do that i.e. have some specific IPs and if those fail then have a fallback to the default behavior. I haven't fount it in the documentation, but on the forum (one of the nicer ones I've seen, +1 for that!).

Perhaps it will be more obvious this way :)

ref https://forum.syncthing.net/t/dynamic-pairing-vs-explicit-ip/5798/4