### PR TITLE
Explain not respecting the pull order

### DIFF
--- a/users/config.rst
+++ b/users/config.rst
@@ -288,6 +288,11 @@ order
         Pull files ordered by modification time; oldest and newest first
         respectively.
 
+    Note that the scanned files are sent in batches and the sorting is applied
+    only to the already discovered files. This means the sync might start with
+    a 1 GB file even if there is 1 KB file available on the source device until
+    the 1 KB becomes known to the pulling device.
+
 ignoreDelete
     When set to true, this device will pretend not to see instructions to
     delete files from other devices.


### PR DESCRIPTION
I think this should be mentioned in the docs to prevent the questions again and to make users understand how syncthing works in the background too. I haven't found the exact number of files for the batch, only `256 << 10`, then `256 KB` and some other references to the sizes, which I don't think will be important for the end-user as from what I've understood those aren't the *file* sizes, but rather the batch content sizes, which would mean basically pseudorandom file count in the batch until the content size is reached (or am I wrong?).

Also I wanted to add info about the alphabetic order, but I haven't found any related test nor sorting code for that via GitHub search, sooo... if you know whether machine sorting or [human sorting](https://blog.codinghorror.com/sorting-for-humans-natural-sort-order/) is used, please comment or add it in there too. :)

Reference:
https://forum.syncthing.net/t/syncthing-does-not-respect-file-pull-order/10856
https://forum.syncthing.net/t/file-pull-order-smallest-first-how-does-this-work/7503