### PR TITLE
users/faq: Add nuance to nested folder statement (fixes #428)

### DIFF
--- a/users/faq.rst
+++ b/users/faq.rst
@@ -206,9 +206,11 @@ See the previous question.
 Am I able to nest shared folders in Syncthing?
 ----------------------------------------------
 
-Do not share a folder which is inside another shared folder. This behaviour
-is in no way supported, recommended or coded for in any way, and comes with
-many pitfalls.
+Sharing a folder that is within an already shared folder is possible, but it has
+its caveats. What you must absolutely avoid are circular shares. This is just
+one example, there may be other undesired effects. Nesting shared folders is not
+supported, recommended or coded for, but it can be done successfully when you
+know what you're doing - you have been warned.
 
 How do I rename/move a synced folder?
 -------------------------------------


### PR DESCRIPTION
My intention was to keep it not recommended, but make it clear that it can be done and mention the one know catastrophic case (circular includes) - I don't think explaining any further is useful, if the user doesn't understand what circular includes are, they just shouldn't do nested folders (or do research aka read the forum).