### PR TITLE
Note the performance impact of negative patterns.

### DIFF
--- a/users/ignoring.rst
+++ b/users/ignoring.rst
@@ -83,6 +83,11 @@ The ``.stignore`` file contains a list of file or path patterns. The
 
    Prefixes can be specified in any order (e.g. "(?d)(?i)"), but cannot be in a
    single pair of parentheses (not ":strike:`(?di)`").
+   
+.. note::
+
+   The use negative patterns (beginning with ``!``) causes Syncthing to perform
+   a full scan of the directory tree regardless of other ignore patterns.
 
 Example
 -------

--- a/users/ignoring.rst
+++ b/users/ignoring.rst
@@ -83,11 +83,12 @@ The ``.stignore`` file contains a list of file or path patterns. The
 
    Prefixes can be specified in any order (e.g. "(?d)(?i)"), but cannot be in a
    single pair of parentheses (not ":strike:`(?di)`").
-   
+
 .. note::
 
-   The use negative patterns (beginning with ``!``) causes Syncthing to perform
-   a full scan of the directory tree regardless of other ignore patterns.
+   Include patterns (that begin with ``!``) cause Syncthing to traverse and
+   :ref:`watch <scanning>` the entire directory tree regardless of other
+   ignore patterns.
 
 Example
 -------

--- a/users/syncing.rst
+++ b/users/syncing.rst
@@ -28,6 +28,8 @@ computed and compared with the expected value. If it matches the block is
 written to a temporary copy of the file, otherwise it is discarded and
 Syncthing tries to find another source for the block.
 
+.. _scanning:
+
 Scanning
 --------
 
@@ -93,4 +95,3 @@ on Windows, ``~syncthing~original-filename.ext.tmp`` where
 normally hidden. If the temporary file name would be too long due to the
 addition of the prefix and extra extension, a hash of the original file name
 is used instead of the actual original file name.
-


### PR DESCRIPTION
Add a note about the performance impact of negative patterns on scans.

## Example
Starting with this ignore pattern:
```
// Ignore everything
*
```

Scanning a folder is instant. Now add any negative patterns:
```
// Includes
!/foo

// Ignore everything
*
```

Now it feels like Syncthing is scanning entire tree.

I also found this [post](https://forum.syncthing.net/t/looking-for-ways-to-speed-up-scanning-on-large-folders/12717/2) by Jakob Borg on the Syncthing forum:

> Ignoring files won’t help. If you can ignore large parts of the tree, like directories at the top level, that would help as there would be less to scan. Don’t use any negative patterns (beginning with !) as Syncthing will then need to do a full scan regardless of the other ignore patterns.