### PR TITLE
Remove bitbar-plugins from list

### DIFF
--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -55,8 +55,6 @@ Mac OS
 
 - `SyncthingBar <https://github.com/nhojb/SyncthingBar>`_
 
-- `BitBar plugin <https://github.com/sebw/bitbar-plugins>`_
-
 Linux
 ~~~~~
 


### PR DESCRIPTION
bitbar-plugins is marked "no longer maintained" in its github page: https://github.com/sebw/bitbar-plugins

Asking the author for confirmation: @sebw