### PR TITLE
Fix the unknown variable error when using nginx

### DIFF
--- a/users/stdiscosrv.rst
+++ b/users/stdiscosrv.rst
@@ -242,7 +242,7 @@ the Syncthing settings.
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $http_connection;
     proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $http_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     proxy_set_header X-SSL-Cert $ssl_client_cert;
     upstream discovery.example.com {

--- a/users/stdiscosrv.rst
+++ b/users/stdiscosrv.rst
@@ -240,10 +240,10 @@ the Syncthing settings.
     proxy_buffering off;
     proxy_set_header Host $http_host;
     proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $proxy_connection;
+    proxy_set_header Connection $http_connection;
     proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
+    proxy_set_header X-Forwarded-For $http_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     proxy_set_header X-SSL-Cert $ssl_client_cert;
     upstream discovery.example.com {
         # Local IP address:port for discovery server


### PR DESCRIPTION
The example config file of Nginx contain multiple errors:

```
proxy_set_header Connection $proxy_connection;
proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
```

When added these lines, Nginx will output something like this:

```
nginx: [emerg] unknown "proxy_connection" variable
```

Tested environment: 

```
Nginx version: nginx/1.14.1
```