### PR TITLE
 advanced/folder-uselargeblocks: Defaults for "useLargeBlocks" have changed

### DIFF
--- a/advanced/folder-uselargeblocks.rst
+++ b/advanced/folder-uselargeblocks.rst
@@ -35,6 +35,6 @@ of an existing file is only changed when the difference in block size
 exceeds one level, i.e., from 256 KiB to 1 MiB, but not from 256 KiB to 512
 KiB.
 
-At some point in the future, `useLargeBlocks` will start defaulting to
-`true`. At some further point in the future, the setting will be removed and
-large blocks will be the only mode of operation.
+Syncthing version 1.1.0 and newer have `useLargeBlocks` enabled by default for
+new folders. At some point in the future, the setting will be removed
+and large blocks will be the only mode of operation.

--- a/dev/building.rst
+++ b/dev/building.rst
@@ -76,7 +76,7 @@ Building (Windows)
 - Open a ``cmd`` Window.
 - Run the commands below.
 
-.. code-block:: cmd
+.. code-block:: batch
 
     # This should output "go version go1.12" or higher.
     > go version


### PR DESCRIPTION
I believe there is no issue for this PR (on the tracker), but since this is a really small change and calmh suggested a PR, I just created this.

Related to this forum discussion: https://forum.syncthing.net/t/variable-block-size-support-on-by-default/13334/

This change updates the documentation and reflects the fact that all Syncthing versions since 1.1.0 have `useLargeBlocks` enabled by default (for new folders).

Additionally, there was an issue with my sphinx nagging me that a lexer called `cmd` does not exist (`dev/building.rst` is the only file declaring this). I fixed this by changing it to `batch` which is recommended by [this](http://pygments.org/docs/lexers/) page. This changes the layout of the code section slightly, it adds a minor amount of syntax highlighting to the Windows section which was previously missing.