### PR TITLE
Allow SPHINXBUILD to be read from the environment.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
+SPHINXBUILD  ?= sphinx-build
 PAPER         =
 BUILDDIR      = _build
 


### PR DESCRIPTION
Without this the Sphinx path is not read from the environment so the suggestion in the error message doesn't work.
