### PR TITLE
Clarify usage of multiple listen addresses

### DIFF
--- a/users/config.rst
+++ b/users/config.rst
@@ -792,8 +792,7 @@ setLowPriority
 Listen Addresses
 ^^^^^^^^^^^^^^^^
 
-The following address types are accepted in sync protocol listen addresses
-(multiple can be specified by comma separation):
+The following address types are accepted in sync protocol listen addresses. If you want Syncthing to listen on multiple addresses, you can have multiple ``<listenAddress></listenAddress>`` sections. The same is achieved in the GUI by entering several addresses separated by comma.
 
 Default listen addresses (``default``)
     This is equivalent to ``tcp://0.0.0.0:22000``, ``quic://0.0.0.0:22000``

--- a/users/config.rst
+++ b/users/config.rst
@@ -792,7 +792,7 @@ setLowPriority
 Listen Addresses
 ^^^^^^^^^^^^^^^^
 
-The following address types are accepted in sync protocol listen addresses. If you want Syncthing to listen on multiple addresses, you can have multiple ``<listenAddress></listenAddress>`` sections. The same is achieved in the GUI by entering several addresses separated by comma.
+The following address types are accepted in sync protocol listen addresses. If you want Syncthing to listen on multiple addresses, you can have multiple ``<listenAddress>`` tags. The same is achieved in the GUI by entering several addresses separated by comma.
 
 Default listen addresses (``default``)
     This is equivalent to ``tcp://0.0.0.0:22000``, ``quic://0.0.0.0:22000``


### PR DESCRIPTION
Before it was not clear how to specify multiple listen addresses in the config file. Before, you would assume to separate them by comma in the <listenAddress> block, which does not work. Comma separation is for the GUI, the config file needs multiple to be specified like this:

```
<listenAddress>ADDRESS1</listenAddress>
<listenAddress>ADDRESS2</listenAddress>
```