### PR TITLE
Add steps for using globally ignored patterns

### DIFF
--- a/users/ignoring.rst
+++ b/users/ignoring.rst
@@ -160,6 +160,11 @@ This file can be synced across all devices and helps with ignoring
 ``.DS_Store`` if you sync a folder between devices where at least one is
 Mac OS and will also cause ``foo`` pattern being ignored on all devices.
 
+.. note::
+   This way in case your syncing gets "stucked" with displaying some
+   pending unexpected files and you can't reach the device that contains
+   those files, simply add it to ``.stglobalignore``.
+
 The important part is to ``#include`` this global ignore file per each
 device so that::
 

--- a/users/ignoring.rst
+++ b/users/ignoring.rst
@@ -142,3 +142,42 @@ all files and directories called "foo", ending in a "2" or starting with
   ``some/directory/`` matches the content of the directory, but not the
   directory itself. If you want the pattern to match the directory and its
   content, make sure it does not have a ``/`` at the end of the pattern.
+
+Ignoring files across all devices
+---------------------------------
+
+Although ``.stignore`` files are not synced between the devices, as mentioned
+previously, we can take an advantage of ``#include`` pattern to create
+a single file that will hold globally ignored patterns.
+
+Let's name it ``.stglobalignore``::
+
+    // Globally ignored patterns
+    (?d).DS_Store
+    foo
+
+This file can be synced across all devices and helps with ignoring
+``.DS_Store`` if you sync a folder between devices where at least one is
+Mac OS and will also cause ``foo`` pattern being ignored on all devices.
+
+The important part is to ``#include`` this global ignore file per each
+device so that::
+
+    // .stignore for 1st Device
+    #include .stglobalignore
+
+    // .stignore for 2nd Device
+    #include .stglobalignore
+
+    ...
+
+    // .stignore for N-th Device
+    #include .stglobalignore
+
+The global ``#include`` does not exclude the possibility to add custom
+patterns per each device.
+
+.. note::
+   This can be added even later with a lot of devices in your personal
+   cloud, but it's a way easier to set up ignoring in the beginning than
+   to include that global file to each device separately.

--- a/users/ignoring.rst
+++ b/users/ignoring.rst
@@ -180,7 +180,7 @@ device so that::
     #include .stglobalignore
 
 The global ``#include`` does not exclude the possibility to add custom
-patterns per each device.
+patterns for single devices.
 
 .. note::
    This can be added even later with a lot of devices already being present

--- a/users/ignoring.rst
+++ b/users/ignoring.rst
@@ -150,7 +150,7 @@ Although ``.stignore`` file is not synced between the devices, as mentioned
 previously, we can take an advantage of ``#include`` pattern to create
 a single file that will hold globally ignored patterns.
 
-Let's name it ``.stglobalignore``::
+Assuming the content of the file is::
 
     // Globally ignored patterns
     (?d).DS_Store

--- a/users/ignoring.rst
+++ b/users/ignoring.rst
@@ -146,7 +146,7 @@ all files and directories called "foo", ending in a "2" or starting with
 Ignoring files across all devices
 ---------------------------------
 
-Although ``.stignore`` files are not synced between the devices, as mentioned
+Although ``.stignore`` file is not synced between the devices, as mentioned
 previously, we can take an advantage of ``#include`` pattern to create
 a single file that will hold globally ignored patterns.
 

--- a/users/ignoring.rst
+++ b/users/ignoring.rst
@@ -161,7 +161,7 @@ This file can be synced across all devices and helps with ignoring
 Mac OS and will also cause ``foo`` pattern being ignored on all devices.
 
 .. note::
-   This way in case your syncing gets "stucked" with displaying some
+   This way in case your syncing gets "stuck" with displaying some
    pending unexpected files and you can't reach the device that contains
    those files, simply add it to ``.stglobalignore``.
 

--- a/users/ignoring.rst
+++ b/users/ignoring.rst
@@ -183,6 +183,6 @@ The global ``#include`` does not exclude the possibility to add custom
 patterns per each device.
 
 .. note::
-   This can be added even later with a lot of devices in your personal
-   cloud, but it's a way easier to set up ignoring in the beginning than
-   to include that global file to each device separately.
+   This can be added even later with a lot of devices already being present
+   in Syncthing, but it's a way easier to set up ignoring in the beginning
+   than to include that global file to each device separately.

--- a/users/ignoring.rst
+++ b/users/ignoring.rst
@@ -147,7 +147,7 @@ Ignoring files across all devices
 ---------------------------------
 
 Although ``.stignore`` file is not synced between the devices, as mentioned
-previously, it's possible to take an advantage of ``#include`` pattern
+previously, it's possible to take advantage of an ``#include`` pattern
 to create a single file that will hold globally ignored patterns.
 
 Assuming the content of the file is::

--- a/users/ignoring.rst
+++ b/users/ignoring.rst
@@ -147,8 +147,8 @@ Ignoring files across all devices
 ---------------------------------
 
 Although ``.stignore`` file is not synced between the devices, as mentioned
-previously, we can take an advantage of ``#include`` pattern to create
-a single file that will hold globally ignored patterns.
+previously, it's possible to take an advantage of ``#include`` pattern
+to create a single file that will hold globally ignored patterns.
 
 Assuming the content of the file is::
 

--- a/users/ignoring.rst
+++ b/users/ignoring.rst
@@ -148,11 +148,11 @@ Ignoring files across all devices
 
 Although ``.stignore`` file is not synced between the devices, as mentioned
 previously, it's possible to take advantage of an ``#include`` pattern
-to create a single file that will hold globally ignored patterns.
+to create a single file that will hold shared ignoring patterns.
 
-Assuming the content of the file is::
+Assuming the content of a file ``.stignore-shared`` is::
 
-    // Globally ignored patterns
+    // Shared ignoring patterns
     (?d).DS_Store
     foo
 
@@ -163,26 +163,26 @@ Mac OS and will also cause ``foo`` pattern being ignored on all devices.
 .. note::
    This way in case your syncing gets "stuck" with displaying some
    pending unexpected files and you can't reach the device that contains
-   those files, simply add it to ``.stglobalignore``.
+   those files, simply add it to ``.stignore-shared``.
 
-The important part is to ``#include`` this global ignore file per each
+The important part is to ``#include`` this shared ignore file per each
 device so that::
 
     // .stignore for 1st Device
-    #include .stglobalignore
+    #include .stignore-shared
 
     // .stignore for 2nd Device
-    #include .stglobalignore
+    #include .stignore-shared
 
     ...
 
     // .stignore for N-th Device
-    #include .stglobalignore
+    #include .stignore-shared
 
-The global ``#include`` does not exclude the possibility to add custom
+The shared ``#include`` does not exclude the possibility to add custom
 patterns for single devices.
 
 .. note::
    This can be added even later with a lot of devices already being present
    in Syncthing, but it's a way easier to set up ignoring in the beginning
-   than to include that global file to each device separately.
+   than to include that shared file to each device separately.

--- a/users/ignoring.rst
+++ b/users/ignoring.rst
@@ -160,11 +160,6 @@ This file can be synced across all devices and helps with ignoring
 ``.DS_Store`` if you sync a folder between devices where at least one is
 Mac OS and will also cause ``foo`` pattern being ignored on all devices.
 
-.. note::
-   This way in case your syncing gets "stuck" with displaying some
-   pending unexpected files and you can't reach the device that contains
-   those files, simply add it to ``.stignore-shared``.
-
 The important part is to ``#include`` this shared ignore file per each
 device so that::
 

--- a/users/ignoring.rst
+++ b/users/ignoring.rst
@@ -50,7 +50,9 @@ The ``.stignore`` file contains a list of file or path patterns. The
    separator. ``te??st`` matches ``tebest`` but not ``teb/st`` or
    ``test``.
 
--  Characters enclosed in square brackets ``[]`` are interpreted as a character range ``[a-z]``. Before using this syntax you should have a basic understanding of regular expression character classes.
+-  Characters enclosed in square brackets ``[]`` are interpreted as a character
+   range ``[a-z]``. Before using this syntax you should have a basic
+   understanding of regular expression character classes.
 
 -  A pattern beginning with ``/`` matches in the current directory only.
    ``/foo`` matches ``foo`` but not ``subdir/foo``.


### PR DESCRIPTION
Introduces a way with ``#include`` to use a single file for globally ignored patterns and a way to unstuck a "stucked" syncing where multiple devices quickly create and remove a lot of files which might not be even desirable (for example ``.#`` for Emacs files or quite annoying ``.DS_Store`` for MacOS and ``desktop.ini`` for Windows).