### PR TITLE
Added links for rsync and Unison

### DIFF
--- a/users/faq.rst
+++ b/users/faq.rst
@@ -238,7 +238,8 @@ Does Syncthing support syncing between folders on the same system?
 
 No. Syncthing is not designed to sync locally and the overhead involved in
 doing so using Syncthing's method would be wasteful. There are better
-programs to achieve this such as rsync or Unison.
+programs to achieve this such as [rsync](https://rsync.samba.org/) or
+[Unison](https://www.cis.upenn.edu/~bcpierce/unison).
 
 When I do have two distinct Syncthing-managed folders on two hosts, how does Syncthing handle moving files between them?
 ------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
While searching on the web for rsync quite likely will land you on it home page, unison is such a generic term and its usage is not that widespread making it relative hard to find just by searching for the name. So provide direct links from the documentation.