### PR TITLE
users/config: Fix closing tag for allowedNetwork

### DIFF
--- a/users/config.rst
+++ b/users/config.rst
@@ -348,7 +348,7 @@ Device Element
     <device id="2CYF2WQ-AKZO2QZ-JAKWLYD-AGHMQUM-BGXUOIS-GYILW34-HJG3DUK-LRRYQAR" name="syno local" compression="metadata" introducer="false">
         <address>tcp://192.0.2.1:22001</address>
         <paused>true<paused>
-        <allowedNetwork>192.168.0.0/16<allowedNetwork>
+        <allowedNetwork>192.168.0.0/16</allowedNetwork>
         <autoAcceptFolders>false</autoAcceptFolders>
         <maxSendKbps>100</maxSendKbps>
         <maxRecvKbps>100</maxRecvKbps>


### PR DESCRIPTION
In the documentation the tags in the example for <device><allowedNetwork> do not closes properly.

## Current behavior

If the config is copied and just changed the needed values, Syncthing will fail to read the config file properly.

## Current configuration example

```
<device ...>
    ...
    <allowedNetwork>192.168.0.0/16<allowedNetwork>
    ...
</device>
```

## Proposed change

```
<device ...>
    ...
    <allowedNetwork>192.168.0.0/16</allowedNetwork>
    ...
</device>
```