### PR TITLE
Update contrib.rst Fix QNAP Link

### DIFF
--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -150,7 +150,7 @@ execute a Syncthing version upgrade via the web GUI after installation.
 QNAP NAS (QTS)
 ~~~~~~~~~~~~~~
 
-`Syncthing QPKG <https://forum.qnap.com/viewtopic.php?f=320&t=97035>`__ (Qnap
+`Syncthing QPKG <https://qnapclub.eu/en/qpkg/692>`__ (Qnap
 Package) available for ALL models x86, x86\_64, Arm (all including new models).
 
 RockStor


### PR DESCRIPTION
Original link results in The Requested Topic Does Not Exist from QNAP. No link or topic found by searching the QNAP forum. Did find package on QnapClub Store but requires additional setup (custom repo). Verified QnapClub store QPKG working correctly on TS-469L, now successfully running Syncthing 1.3.1.