### PR TITLE
dev/rest: Mention -k flag for curl with https

### DIFF
--- a/dev/rest.rst
+++ b/dev/rest.rst
@@ -16,7 +16,7 @@ generated in the GUI, or set in the ``configuration/gui/apikey`` element in
 the configuration file. To use an API key, set the request header
 ``X-API-Key`` to the API key value. For example, ``curl -X POST -H
 "X-API-Key: abc123" http://localhost:8384/rest/...`` can be used to invoke
-with ``curl``.
+with ``curl`` (add ``-k`` flag to curl command when using https).
 
 System Endpoints
 ----------------

--- a/dev/rest.rst
+++ b/dev/rest.rst
@@ -16,7 +16,7 @@ generated in the GUI, or set in the ``configuration/gui/apikey`` element in
 the configuration file. To use an API key, set the request header
 ``X-API-Key`` to the API key value. For example, ``curl -X POST -H
 "X-API-Key: abc123" http://localhost:8384/rest/...`` can be used to invoke
-with ``curl`` (add ``-k`` flag to curl command when using https).
+with ``curl`` (add ``-k`` flag when using HTTPS with a Syncthing generated or self signed certificate).
 
 System Endpoints
 ----------------


### PR DESCRIPTION
Every now and  then when asking for a rest output some CSRF error comes up due to missing `-k` (and it took me way to long to remember what the reason was). So lets just document it.