### PR TITLE
Update autostart.rst

### DIFF
--- a/users/autostart.rst
+++ b/users/autostart.rst
@@ -219,6 +219,10 @@ Go to ``/etc/supervisor/conf.d/`` and create a new file named ``syncthing.conf``
     command = /usr/bin/syncthing -no-browser -home="/home/<USERNAME>/.config/syncthing"
     environment = STNORESTART="1", HOME="/home/<USERNAME>"
 
+Reload Supervisord::
+
+    supervisorctl reload
+
 Then start it::
 
     supervisorctl start syncthing


### PR DESCRIPTION
You need to reload supervisorctl before to avoid getting this error: "syncthing: ERROR (no such process)".