### PR TITLE
users/autostart: Improve configuration for Task Scheduler in Windows

### DIFF
--- a/users/autostart.rst
+++ b/users/autostart.rst
@@ -36,7 +36,6 @@ Task Scheduler
     #. Click "New..."
     #. [Action] should be set as "Start a program"
     #. Enter the path to syncthing.exe in "Program/Script"
-    #. (optional) Enter "-no-console -no-browser" for "Add arguments (optional)"
     #. (optional) Enter the path to the parent folder of syncthing.exe in "Start in (optional)". This will allow you to use paths relative to this folder in Syncthing.
     #. Click "OK"
 #. Settings Tab:

--- a/users/autostart.rst
+++ b/users/autostart.rst
@@ -20,31 +20,31 @@ there are a number of easy solutions.
 Task Scheduler
 ~~~~~~~~~~~~~~
 
-#. Start the `Task Scheduler <https://en.wikipedia.org/wiki/Windows_Task_Scheduler>`__ (``taskschd.msc``)
-#. Create a New Task ("Action" menu -> "Create Task...")
+#. Start the `Task Scheduler <https://en.wikipedia.org/wiki/Windows_Task_Scheduler>`__ (``taskschd.msc``).
+#. Create a New Task ("Action" menu -> "Create Task...").
 #. General Tab:
-    #. Name the task (for example 'Syncthing')
-    #. Check "Run whether user is logged on or not"
+    #. Name the task (for example 'Syncthing').
+    #. Check "Run whether user is logged on or not".
     #. (recommended) Check "Do not store password. The task will only have access to local resources". Leave this option unchecked if you intend to store your folders on network drives and such.
 #. Triggers Tab:
-    #. Click "New..."
-    #. Set "Begin the task" to "At Startup"
-    #. (optional) choose a delay
-    #. Make sure Enabled is checked
-    #. Click "OK"
+    #. Click "New...".
+    #. Set "Begin the task" to "At Startup".
+    #. (optional) choose a delay.
+    #. Make sure Enabled is checked.
+    #. Click "OK".
 #. Actions Tab:
-    #. Click "New..."
-    #. [Action] should be set as "Start a program"
-    #. Enter the path to syncthing.exe in "Program/Script"
+    #. Click "New...".
+    #. [Action] should be set as "Start a program".
+    #. Enter the path to syncthing.exe in "Program/Script".
     #. (optional) Enter the path to the parent folder of syncthing.exe in "Start in (optional)". This will allow you to use paths relative to this folder in Syncthing.
-    #. Click "OK"
+    #. Click "OK".
 #. Conditions Tab:
     #. (optional) Uncheck "Stop if the computer switches to battery power". Note that unchecking "Start the task only if the computer is on AC power" does not disable this option. Even if greyed out, it still applies, and has to be unchecked separately.
-    #. (optional) Uncheck "Start the task only if the computer is on AC power"
+    #. (optional) Uncheck "Start the task only if the computer is on AC power".
     #. (optional) Check "Start only if the following network connection is available" and set to "Network". Use this option on a laptop, when you want Syncthing to start only on a wired Internet connection, and not on Wi-Fi. Note that once started, Syncthing will not stop running if the connection changes or becomes unavailable later.
 #. Settings Tab:
-    #. Clear checkbox from "Stop task if it runs longer than:"
-#. Click OK
+    #. Clear checkbox from "Stop task if it runs longer than:".
+#. Click OK.
 #. If prompted, enter password for the user.
 
 Third-party Tools

--- a/users/autostart.rst
+++ b/users/autostart.rst
@@ -25,6 +25,7 @@ Task Scheduler
 #. General Tab:
     #. Name the task (for example 'Syncthing')
     #. Check "Run whether user is logged on or not"
+    #. (recommended) Check "Do not store password. The task will only have access to local resources". Leave this option unchecked if you intend to store your folders on network drives and such.
 #. Triggers Tab:
     #. Click "New..."
     #. Set "Begin the task" to "At Startup"
@@ -42,7 +43,7 @@ Task Scheduler
     #. Clear checkbox from "Stop task if it runs longer than:"
     #. (recommended) Keep "Do not start a new instance" for "If the task is already running, then the following rule applies"
 #. Click OK
-#. Enter password for the user.
+#. If prompted, enter password for the user.
 
 Third-party Tools
 ~~~~~~~~~~~~~~~~~

--- a/users/autostart.rst
+++ b/users/autostart.rst
@@ -39,7 +39,9 @@ Task Scheduler
     #. (optional) Enter the path to the parent folder of syncthing.exe in "Start in (optional)". This will allow you to use paths relative to this folder in Syncthing.
     #. Click "OK"
 #. Conditions Tab:
-    #. (optional) Uncheck "Stop if the computer switches to battery power"
+    #. (optional) Uncheck "Stop if the computer switches to battery power". Note that unchecking "Start the task only if the computer is on AC power" does not disable this option. Even if greyed out, it still applies, and has to be unchecked separately.
+    #. (optional) Uncheck "Start the task only if the computer is on AC power"
+    #. (optional) Check "Start only if the following network connection is available" and set to "Network". Use this option on a laptop, when you want Syncthing to start only on a wired Internet connection, and not on Wi-Fi. Note that once started, Syncthing will not stop running if the connection changes or becomes unavailable later.
 #. Settings Tab:
     #. (recommended) Keep the checkbox on "Allow task to be run on demand"
     #. Clear checkbox from "Stop task if it runs longer than:"

--- a/users/autostart.rst
+++ b/users/autostart.rst
@@ -29,7 +29,7 @@ Task Scheduler
 #. Triggers Tab:
     #. Click "New...".
     #. Set "Begin the task" to "At Startup".
-    #. (optional) choose a delay.
+    #. (optional) Choose a delay.
     #. Make sure Enabled is checked.
     #. Click "OK".
 #. Actions Tab:

--- a/users/autostart.rst
+++ b/users/autostart.rst
@@ -38,6 +38,8 @@ Task Scheduler
     #. Enter the path to syncthing.exe in "Program/Script"
     #. (optional) Enter the path to the parent folder of syncthing.exe in "Start in (optional)". This will allow you to use paths relative to this folder in Syncthing.
     #. Click "OK"
+#. Conditions Tab:
+    #. (optional) Uncheck "Stop if the computer switches to battery power"
 #. Settings Tab:
     #. (recommended) Keep the checkbox on "Allow task to be run on demand"
     #. Clear checkbox from "Stop task if it runs longer than:"

--- a/users/autostart.rst
+++ b/users/autostart.rst
@@ -43,9 +43,7 @@ Task Scheduler
     #. (optional) Uncheck "Start the task only if the computer is on AC power"
     #. (optional) Check "Start only if the following network connection is available" and set to "Network". Use this option on a laptop, when you want Syncthing to start only on a wired Internet connection, and not on Wi-Fi. Note that once started, Syncthing will not stop running if the connection changes or becomes unavailable later.
 #. Settings Tab:
-    #. (recommended) Keep the checkbox on "Allow task to be run on demand"
     #. Clear checkbox from "Stop task if it runs longer than:"
-    #. (recommended) Keep "Do not start a new instance" for "If the task is already running, then the following rule applies"
 #. Click OK
 #. If prompted, enter password for the user.
 

--- a/users/autostart.rst
+++ b/users/autostart.rst
@@ -37,6 +37,7 @@ Task Scheduler
     #. [Action] should be set as "Start a program"
     #. Enter the path to syncthing.exe in "Program/Script"
     #. (optional) Enter "-no-console -no-browser" for "Add arguments (optional)"
+    #. (optional) Enter the path to the parent folder of syncthing.exe in "Start in (optional)". This will allow you to use paths relative to this folder in Syncthing.
     #. Click "OK"
 #. Settings Tab:
     #. (recommended) Keep the checkbox on "Allow task to be run on demand"


### PR DESCRIPTION
* Recommend not to save passwords in Task Scheduler

Saving user passwords is only required to access non-local resources,
such as network drives, etc. This may present a security a risk, and
also should not be needed in a standard Syncthing installation, where
the folders are located on local drives.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

* Add optional 'Start in' path to Task Scheduler

Adding a specific directory to the 'Start in' field in Task Scheduler
allows to use folder paths relative to this folder in Syncthing. If
unset, Windows defaults to %SystemRoot%\System32, which may lead to
unexpected consequences for the unaware users.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

* Remove command line arguments from Task Scheduler

With "Run whether user is logged on or not", Task Scheduler starts
processes in background without any visible GUI. Therefore, the
arguments -no-console and -no-browser are superfluous, since neither
a command line window nor a browser window opens in this state.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

* Add options to run on battery in Task Scheduler

Add new optional settings for the Conditions tab in Task Scheduler.
Despite the parent-child relationship in the GUI, these two options are
in fact separate, i.e. disabling the parent does not disable the child.
Therefore, "Stop if the computer switches to battery power" needs to be
unchecked first, and "Start the task only if the computer is on AC power"
later.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

* Add option not to run on Wi-Fi in Task Scheduler

It is possible to set Task Scheduler to start a task only when a
specific network connection is available. This way, we can make
Syncthing start only on wired connections, and not on others, e.g.
Wi-Fi. This can be done, because Windows labels wired connections
"Network", while wireless connections all have their own SSIDs.

This still has some limitations, especially when there are multiple
wired network adapters installed, but should be enough for typical
desktop or laptop computers.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

* Remove unneeded recommendations from Settings in Task Scheduler

Both "Allow task to be run on demand" and "Do not start a new instance"
are checked by default, and there is no need to touch them, unless the
user specifically wants to. Therefore, it is unnecessary to specifically
recommend having them checked. Moreover, Syncthing will still run in
background on system start anyway, regardless if the user decides to
fiddle with these two options or not.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

* Add punctuation to instructions for Task Scheduler

Add full stops after each sentence in the Task Scheduler instructions.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

* Fix capital letters in instructions for Task Scheduler

Each sentence should begin with a capital letter.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>