### PR TITLE
users/config: Update example config to match Syncthing v1.5.0

### DIFF
--- a/users/config.rst
+++ b/users/config.rst
@@ -129,6 +129,7 @@ The following shows an example of the default configuration file (IDs will diffe
             <stunKeepaliveStartS>180</stunKeepaliveStartS>
             <stunKeepaliveMinS>20</stunKeepaliveMinS>
             <stunServer>default</stunServer>
+            <databaseTuning>auto</databaseTuning>
         </options>
     </configuration>
 

--- a/users/config.rst
+++ b/users/config.rst
@@ -130,6 +130,7 @@ The following shows an example of the default configuration file (IDs will diffe
             <stunKeepaliveMinS>20</stunKeepaliveMinS>
             <stunServer>default</stunServer>
             <databaseTuning>auto</databaseTuning>
+            <maxConcurrentIncomingRequestKiB>0</maxConcurrentIncomingRequestKiB>
         </options>
     </configuration>
 

--- a/users/config.rst
+++ b/users/config.rst
@@ -69,6 +69,7 @@ The following shows an example of the default configuration file (IDs will diffe
             <weakHashThresholdPct>25</weakHashThresholdPct>
             <markerName>.stfolder</markerName>
             <copyOwnershipFromParent>false</copyOwnershipFromParent>
+            <modTimeWindowS>0</modTimeWindowS>
         </folder>
         <device id="3LT2GA5-CQI4XJM-WTZ264P-MLOGMHL-MCRLDNT-MZV4RD3-KA745CL-OGAERQZ" name="syno" compression="metadata" introducer="false" skipIntroductionRemovals="false" introducedBy="">
             <address>dynamic</address>

--- a/users/config.rst
+++ b/users/config.rst
@@ -68,6 +68,7 @@ The following shows an example of the default configuration file (IDs will diffe
             <paused>false</paused>
             <weakHashThresholdPct>25</weakHashThresholdPct>
             <markerName>.stfolder</markerName>
+            <copyOwnershipFromParent>false</copyOwnershipFromParent>
         </folder>
         <device id="3LT2GA5-CQI4XJM-WTZ264P-MLOGMHL-MCRLDNT-MZV4RD3-KA745CL-OGAERQZ" name="syno" compression="metadata" introducer="false" skipIntroductionRemovals="false" introducedBy="">
             <address>dynamic</address>

--- a/users/config.rst
+++ b/users/config.rst
@@ -103,7 +103,7 @@ The following shows an example of the default configuration file (IDs will diffe
             <natRenewalMinutes>30</natRenewalMinutes>
             <natTimeoutSeconds>10</natTimeoutSeconds>
             <urAccepted>-1</urAccepted>
-            <urSeen>0</urSeen>
+            <urSeen>3</urSeen>
             <urUniqueID>LFWe2vn3</urUniqueID>
             <urURL>https://data.syncthing.net/newdata</urURL>
             <urPostInsecurely>false</urPostInsecurely>

--- a/users/config.rst
+++ b/users/config.rst
@@ -77,6 +77,7 @@ The following shows an example of the default configuration file (IDs will diffe
             <autoAcceptFolders>false</autoAcceptFolders>
             <maxSendKbps>0</maxSendKbps>
             <maxRecvKbps>0</maxRecvKbps>
+            <maxRequestKiB>0</maxRequestKiB>
         </device>
         <gui enabled="true" tls="false" debugging="false">
             <address>127.0.0.1:8384</address>

--- a/users/config.rst
+++ b/users/config.rst
@@ -123,6 +123,7 @@ The following shows an example of the default configuration file (IDs will diffe
             <defaultFolderPath>~</defaultFolderPath>
             <setLowPriority>true</setLowPriority>
             <maxFolderConcurrency>0</maxFolderConcurrency>
+            <crashReportingURL>https://crash.syncthing.net/newcrash</crashReportingURL>
             <stunServer>default</stunServer>
             <stunKeepaliveSeconds>24</stunKeepaliveSeconds>
             <minHomeDiskFreePct>0</minHomeDiskFreePct>

--- a/users/config.rst
+++ b/users/config.rst
@@ -76,6 +76,7 @@ The following shows an example of the default configuration file (IDs will diffe
             <paused>false</paused>
             <autoAcceptFolders>false</autoAcceptFolders>
             <maxSendKbps>0</maxSendKbps>
+            <maxRecvKbps>0</maxRecvKbps>
         </device>
         <gui enabled="true" tls="false" debugging="false">
             <address>127.0.0.1:8384</address>

--- a/users/config.rst
+++ b/users/config.rst
@@ -50,7 +50,7 @@ The following shows an example of the default configuration file (IDs will diffe
 .. code-block:: xml
 
     <configuration version="30">
-        <folder id="zj2AA-q55a7" label="Default Folder" path="/Users/jb/Sync/" type="sendreceive" rescanIntervalS="3600" fsWatcherEnabled="true" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
+        <folder id="default" label="Default Folder" path="/Users/jb/Sync/" type="sendreceive" rescanIntervalS="3600" fsWatcherEnabled="true" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
             <filesystemType>basic</filesystemType>
             <device id="3LT2GA5-CQI4XJM-WTZ264P-MLOGMHL-MCRLDNT-MZV4RD3-KA745CL-OGAERQZ"></device>
             <minDiskFree unit="%">1</minDiskFree>

--- a/users/config.rst
+++ b/users/config.rst
@@ -128,7 +128,6 @@ The following shows an example of the default configuration file (IDs will diffe
             <stunKeepaliveStartS>180</stunKeepaliveStartS>
             <stunKeepaliveMinS>20</stunKeepaliveMinS>
             <stunServer>default</stunServer>
-            <minHomeDiskFreePct>0</minHomeDiskFreePct>
         </options>
     </configuration>
 

--- a/users/config.rst
+++ b/users/config.rst
@@ -174,13 +174,13 @@ Folder Element
 
 .. code-block:: xml
 
-    <folder id="zj2AA-q55a7" label="Default Folder" path="/Users/jb/Sync/" type="sendreceive" rescanIntervalS="60" fsWatcherEnabled="false" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
-        <device id="3LT2GA5-CQI4XJM-WTZ264P-MLOGMHL-MCRLDNT-MZV4RD3-KA745CL-OGAERQZ"></device>
+    <folder id="default" label="Default Folder" path="/Users/jb/Sync/" type="sendreceive" rescanIntervalS="3600" fsWatcherEnabled="true" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
         <filesystemType>basic</filesystemType>
+        <device id="3LT2GA5-CQI4XJM-WTZ264P-MLOGMHL-MCRLDNT-MZV4RD3-KA745CL-OGAERQZ"></device>
         <minDiskFree unit="%">1</minDiskFree>
         <versioning></versioning>
         <copiers>0</copiers>
-        <pullers>0</pullers>
+        <pullerMaxPendingKiB>0</pullerMaxPendingKiB>
         <hashers>0</hashers>
         <order>random</order>
         <ignoreDelete>false</ignoreDelete>
@@ -192,6 +192,8 @@ Folder Element
         <paused>false</paused>
         <weakHashThresholdPct>25</weakHashThresholdPct>
         <markerName>.stfolder</markerName>
+        <copyOwnershipFromParent>false</copyOwnershipFromParent>
+        <modTimeWindowS>0</modTimeWindowS>
     </folder>
 
 One or more ``folder`` elements must be present in the file. Each element

--- a/users/config.rst
+++ b/users/config.rst
@@ -50,7 +50,7 @@ The following shows an example of the default configuration file (IDs will diffe
 .. code-block:: xml
 
     <configuration version="30">
-        <folder id="zj2AA-q55a7" label="Default Folder" path="/Users/jb/Sync/" type="sendreceive" rescanIntervalS="60" fsWatcherEnabled="false" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
+        <folder id="zj2AA-q55a7" label="Default Folder" path="/Users/jb/Sync/" type="sendreceive" rescanIntervalS="3600" fsWatcherEnabled="false" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
             <device id="3LT2GA5-CQI4XJM-WTZ264P-MLOGMHL-MCRLDNT-MZV4RD3-KA745CL-OGAERQZ"></device>
             <filesystemType>basic</filesystemType>
             <minDiskFree unit="%">1</minDiskFree>

--- a/users/config.rst
+++ b/users/config.rst
@@ -102,7 +102,7 @@ The following shows an example of the default configuration file (IDs will diffe
             <natLeaseMinutes>60</natLeaseMinutes>
             <natRenewalMinutes>30</natRenewalMinutes>
             <natTimeoutSeconds>10</natTimeoutSeconds>
-            <urAccepted>0</urAccepted>
+            <urAccepted>-1</urAccepted>
             <urSeen>0</urSeen>
             <urUniqueID>LFWe2vn3</urUniqueID>
             <urURL>https://data.syncthing.net/newdata</urURL>

--- a/users/config.rst
+++ b/users/config.rst
@@ -139,10 +139,11 @@ Configuration Element
 
 .. code-block:: xml
 
-    <configuration version="26">
+    <configuration version="30">
         <folder></folder>
         <device></device>
         <gui></gui>
+        <ldap></ldap>
         <options></options>
         <ignoredDevice>5SYI2FS-LW6YAXI-JJDYETS-NDBBPIO-256MWBO-XDPXWVG-24QPUM4-PDW4UQU</ignoredDevice>
         <ignoredFolder>bd7q3-zskm5</ignoredFolder>

--- a/users/config.rst
+++ b/users/config.rst
@@ -122,6 +122,7 @@ The following shows an example of the default configuration file (IDs will diffe
             <trafficClass>0</trafficClass>
             <defaultFolderPath>~</defaultFolderPath>
             <setLowPriority>true</setLowPriority>
+            <maxFolderConcurrency>0</maxFolderConcurrency>
             <stunServer>default</stunServer>
             <stunKeepaliveSeconds>24</stunKeepaliveSeconds>
             <minHomeDiskFreePct>0</minHomeDiskFreePct>

--- a/users/config.rst
+++ b/users/config.rst
@@ -121,10 +121,10 @@ The following shows an example of the default configuration file (IDs will diffe
             <tempIndexMinBlocks>10</tempIndexMinBlocks>
             <trafficClass>0</trafficClass>
             <defaultFolderPath>~</defaultFolderPath>
+            <setLowPriority>true</setLowPriority>
             <stunServer>default</stunServer>
             <stunKeepaliveSeconds>24</stunKeepaliveSeconds>
             <minHomeDiskFreePct>0</minHomeDiskFreePct>
-            <setLowPriority>true</setLowPriority>
         </options>
     </configuration>
 

--- a/users/config.rst
+++ b/users/config.rst
@@ -124,6 +124,7 @@ The following shows an example of the default configuration file (IDs will diffe
             <setLowPriority>true</setLowPriority>
             <maxFolderConcurrency>0</maxFolderConcurrency>
             <crashReportingURL>https://crash.syncthing.net/newcrash</crashReportingURL>
+            <crashReportingEnabled>true</crashReportingEnabled>
             <stunServer>default</stunServer>
             <stunKeepaliveSeconds>24</stunKeepaliveSeconds>
             <minHomeDiskFreePct>0</minHomeDiskFreePct>

--- a/users/config.rst
+++ b/users/config.rst
@@ -362,10 +362,15 @@ Device Element
 
     <device id="5SYI2FS-LW6YAXI-JJDYETS-NDBBPIO-256MWBO-XDPXWVG-24QPUM4-PDW4UQU" name="syno" compression="metadata" introducer="false" skipIntroductionRemovals="false" introducedBy="2CYF2WQ-AKZO2QZ-JAKWLYD-AGHMQUM-BGXUOIS-GYILW34-HJG3DUK-LRRYQAR">
         <address>dynamic</address>
+        <paused>false</paused>
+        <autoAcceptFolders>false</autoAcceptFolders>
+        <maxSendKbps>0</maxSendKbps>
+        <maxRecvKbps>0</maxRecvKbps>
+        <maxRequestKiB>0</maxRequestKiB>
     </device>
-    <device id="2CYF2WQ-AKZO2QZ-JAKWLYD-AGHMQUM-BGXUOIS-GYILW34-HJG3DUK-LRRYQAR" name="syno local" compression="metadata" introducer="false">
+    <device id="2CYF2WQ-AKZO2QZ-JAKWLYD-AGHMQUM-BGXUOIS-GYILW34-HJG3DUK-LRRYQAR" name="syno local" compression="metadata" introducer="false" skipIntroductionRemovals="false" introducedBy="">
         <address>tcp://192.0.2.1:22001</address>
-        <paused>true<paused>
+        <paused>true</paused>
         <allowedNetwork>192.168.0.0/16</allowedNetwork>
         <autoAcceptFolders>false</autoAcceptFolders>
         <maxSendKbps>100</maxSendKbps>

--- a/users/config.rst
+++ b/users/config.rst
@@ -51,8 +51,8 @@ The following shows an example of the default configuration file (IDs will diffe
 
     <configuration version="30">
         <folder id="zj2AA-q55a7" label="Default Folder" path="/Users/jb/Sync/" type="sendreceive" rescanIntervalS="3600" fsWatcherEnabled="true" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
-            <device id="3LT2GA5-CQI4XJM-WTZ264P-MLOGMHL-MCRLDNT-MZV4RD3-KA745CL-OGAERQZ"></device>
             <filesystemType>basic</filesystemType>
+            <device id="3LT2GA5-CQI4XJM-WTZ264P-MLOGMHL-MCRLDNT-MZV4RD3-KA745CL-OGAERQZ"></device>
             <minDiskFree unit="%">1</minDiskFree>
             <versioning></versioning>
             <copiers>0</copiers>

--- a/users/config.rst
+++ b/users/config.rst
@@ -50,7 +50,7 @@ The following shows an example of the default configuration file (IDs will diffe
 .. code-block:: xml
 
     <configuration version="30">
-        <folder id="zj2AA-q55a7" label="Default Folder" path="/Users/jb/Sync/" type="sendreceive" rescanIntervalS="3600" fsWatcherEnabled="false" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
+        <folder id="zj2AA-q55a7" label="Default Folder" path="/Users/jb/Sync/" type="sendreceive" rescanIntervalS="3600" fsWatcherEnabled="true" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
             <device id="3LT2GA5-CQI4XJM-WTZ264P-MLOGMHL-MCRLDNT-MZV4RD3-KA745CL-OGAERQZ"></device>
             <filesystemType>basic</filesystemType>
             <minDiskFree unit="%">1</minDiskFree>

--- a/users/config.rst
+++ b/users/config.rst
@@ -120,9 +120,9 @@ The following shows an example of the default configuration file (IDs will diffe
             <overwriteRemoteDeviceNamesOnConnect>false</overwriteRemoteDeviceNamesOnConnect>
             <tempIndexMinBlocks>10</tempIndexMinBlocks>
             <trafficClass>0</trafficClass>
+            <defaultFolderPath>~</defaultFolderPath>
             <stunServer>default</stunServer>
             <stunKeepaliveSeconds>24</stunKeepaliveSeconds>
-            <defaultFolderPath>~</defaultFolderPath>
             <minHomeDiskFreePct>0</minHomeDiskFreePct>
             <setLowPriority>true</setLowPriority>
         </options>

--- a/users/config.rst
+++ b/users/config.rst
@@ -75,6 +75,7 @@ The following shows an example of the default configuration file (IDs will diffe
             <address>dynamic</address>
             <paused>false</paused>
             <autoAcceptFolders>false</autoAcceptFolders>
+            <maxSendKbps>0</maxSendKbps>
         </device>
         <gui enabled="true" tls="false" debugging="false">
             <address>127.0.0.1:8384</address>

--- a/users/config.rst
+++ b/users/config.rst
@@ -49,7 +49,7 @@ The following shows an example of the default configuration file (IDs will diffe
 
 .. code-block:: xml
 
-    <configuration version="26">
+    <configuration version="30">
         <folder id="zj2AA-q55a7" label="Default Folder" path="/Users/jb/Sync/" type="sendreceive" rescanIntervalS="60" fsWatcherEnabled="false" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
             <device id="3LT2GA5-CQI4XJM-WTZ264P-MLOGMHL-MCRLDNT-MZV4RD3-KA745CL-OGAERQZ"></device>
             <filesystemType>basic</filesystemType>

--- a/users/config.rst
+++ b/users/config.rst
@@ -85,7 +85,8 @@ The following shows an example of the default configuration file (IDs will diffe
             <theme>default</theme>
         </gui>
         <options>
-            <listenAddress>default</listenAddress>
+            <listenAddress>tcp://0.0.0.0:8384</listenAddress>
+            <listenAddress>dynamic+https://relays.syncthing.net/endpoint</listenAddress>
             <globalAnnounceServer>default</globalAnnounceServer>
             <globalAnnounceEnabled>true</globalAnnounceEnabled>
             <localAnnounceEnabled>true</localAnnounceEnabled>

--- a/users/config.rst
+++ b/users/config.rst
@@ -74,6 +74,7 @@ The following shows an example of the default configuration file (IDs will diffe
         <device id="3LT2GA5-CQI4XJM-WTZ264P-MLOGMHL-MCRLDNT-MZV4RD3-KA745CL-OGAERQZ" name="syno" compression="metadata" introducer="false" skipIntroductionRemovals="false" introducedBy="">
             <address>dynamic</address>
             <paused>false</paused>
+            <autoAcceptFolders>false</autoAcceptFolders>
         </device>
         <gui enabled="true" tls="false" debugging="false">
             <address>127.0.0.1:8384</address>

--- a/users/config.rst
+++ b/users/config.rst
@@ -125,8 +125,9 @@ The following shows an example of the default configuration file (IDs will diffe
             <maxFolderConcurrency>0</maxFolderConcurrency>
             <crashReportingURL>https://crash.syncthing.net/newcrash</crashReportingURL>
             <crashReportingEnabled>true</crashReportingEnabled>
+            <stunKeepaliveStartS>180</stunKeepaliveStartS>
+            <stunKeepaliveMinS>20</stunKeepaliveMinS>
             <stunServer>default</stunServer>
-            <stunKeepaliveSeconds>24</stunKeepaliveSeconds>
             <minHomeDiskFreePct>0</minHomeDiskFreePct>
         </options>
     </configuration>

--- a/users/config.rst
+++ b/users/config.rst
@@ -104,7 +104,7 @@ The following shows an example of the default configuration file (IDs will diffe
             <natTimeoutSeconds>10</natTimeoutSeconds>
             <urAccepted>-1</urAccepted>
             <urSeen>3</urSeen>
-            <urUniqueID>LFWe2vn3</urUniqueID>
+            <urUniqueID></urUniqueID>
             <urURL>https://data.syncthing.net/newdata</urURL>
             <urPostInsecurely>false</urPostInsecurely>
             <urInitialDelayS>1800</urInitialDelayS>

--- a/users/config.rst
+++ b/users/config.rst
@@ -607,7 +607,8 @@ Options Element
 .. code-block:: xml
 
     <options>
-        <listenAddress>default</listenAddress>
+        <listenAddress>tcp://0.0.0.0:8384</listenAddress>
+        <listenAddress>dynamic+https://relays.syncthing.net/endpoint</listenAddress>
         <globalAnnounceServer>default</globalAnnounceServer>
         <globalAnnounceEnabled>true</globalAnnounceEnabled>
         <localAnnounceEnabled>true</localAnnounceEnabled>
@@ -623,22 +624,34 @@ Options Element
         <natLeaseMinutes>60</natLeaseMinutes>
         <natRenewalMinutes>30</natRenewalMinutes>
         <natTimeoutSeconds>10</natTimeoutSeconds>
-        <urAccepted>0</urAccepted>
+        <urAccepted>-1</urAccepted>
+        <urSeen>3</urSeen>
         <urUniqueID></urUniqueID>
         <urURL>https://data.syncthing.net/newdata</urURL>
         <urPostInsecurely>false</urPostInsecurely>
         <urInitialDelayS>1800</urInitialDelayS>
         <restartOnWakeup>true</restartOnWakeup>
         <autoUpgradeIntervalH>12</autoUpgradeIntervalH>
+        <upgradeToPreReleases>false</upgradeToPreReleases>
         <keepTemporariesH>24</keepTemporariesH>
         <cacheIgnoredFiles>false</cacheIgnoredFiles>
         <progressUpdateIntervalS>5</progressUpdateIntervalS>
         <limitBandwidthInLan>false</limitBandwidthInLan>
         <minHomeDiskFree unit="%">1</minHomeDiskFree>
-        <releasesURL>https://api.github.com/repos/syncthing/syncthing/releases?per_page=30</releasesURL>
+        <releasesURL>https://upgrades.syncthing.net/meta.json</releasesURL>
         <overwriteRemoteDeviceNamesOnConnect>false</overwriteRemoteDeviceNamesOnConnect>
         <tempIndexMinBlocks>10</tempIndexMinBlocks>
+        <trafficClass>0</trafficClass>
         <defaultFolderPath>~</defaultFolderPath>
+        <setLowPriority>true</setLowPriority>
+        <maxFolderConcurrency>0</maxFolderConcurrency>
+        <crashReportingURL>https://crash.syncthing.net/newcrash</crashReportingURL>
+        <crashReportingEnabled>true</crashReportingEnabled>
+        <stunKeepaliveStartS>180</stunKeepaliveStartS>
+        <stunKeepaliveMinS>20</stunKeepaliveMinS>
+        <stunServer>default</stunServer>
+        <databaseTuning>auto</databaseTuning>
+        <maxConcurrentIncomingRequestKiB>0</maxConcurrentIncomingRequestKiB>
     </options>
 
 The ``options`` element contains all other global configuration options.

--- a/users/config.rst
+++ b/users/config.rst
@@ -56,7 +56,7 @@ The following shows an example of the default configuration file (IDs will diffe
             <minDiskFree unit="%">1</minDiskFree>
             <versioning></versioning>
             <copiers>0</copiers>
-            <pullers>0</pullers>
+            <pullerMaxPendingKiB>0</pullerMaxPendingKiB>
             <hashers>0</hashers>
             <order>random</order>
             <ignoreDelete>false</ignoreDelete>

--- a/users/config.rst
+++ b/users/config.rst
@@ -84,6 +84,7 @@ The following shows an example of the default configuration file (IDs will diffe
             <apikey>k1dnz1Dd0rzTBjjFFh7CXPnrF12C49B1</apikey>
             <theme>default</theme>
         </gui>
+        <ldap></ldap>
         <options>
             <listenAddress>tcp://0.0.0.0:8384</listenAddress>
             <listenAddress>dynamic+https://relays.syncthing.net/endpoint</listenAddress>


### PR DESCRIPTION
Update the Config File Format example to match the default configuration
file used in Syncthing v1.5.0. Also, update the Configuration, Folder,
Device, and Options Elements accordingly. The GUI and LDAP Elements do
not need to be updated.

Add:
- autoAcceptFolders
- copyOwnershipFromParent
- crashReportingEnabled
- crashReportingURL
- databaseTuning
- ldap
- maxConcurrentIncomingRequestKiB
- maxFolderConcurrency
- maxRecvKbps
- maxRequestKiB
- maxSendKbps
- modTimeWindowS

Change order:
- defaultFolderPath
- filesystemType
- setLowPriority

Change value:
- fsWatcherEnabled (to "true")
- id (to "default")
- listenAddress (to "tcp://0.0.0.0:8384" and "dynamic+https://relays.syncthing.net/endpoint")
- rescanIntervalS (to "3600")
- urAccepted (to "-1")
- urSeen (to "3")
- urUniqueID (to "")
- version (to "30")

Remove:
- minHomeDiskFreePct

Replace:
- pullers (with pullerMaxPendingKiB)
- stunKeepaliveSeconds (with stunKeepaliveStartS and stunKeepaliveMinS)