### PR TITLE
users/config: Fix default values of urAccepted and urSeen

### DIFF
--- a/users/config.rst
+++ b/users/config.rst
@@ -103,8 +103,8 @@ The following shows an example of the default configuration file (IDs will diffe
             <natLeaseMinutes>60</natLeaseMinutes>
             <natRenewalMinutes>30</natRenewalMinutes>
             <natTimeoutSeconds>10</natTimeoutSeconds>
-            <urAccepted>-1</urAccepted>
-            <urSeen>3</urSeen>
+            <urAccepted>0</urAccepted>
+            <urSeen>0</urSeen>
             <urUniqueID></urUniqueID>
             <urURL>https://data.syncthing.net/newdata</urURL>
             <urPostInsecurely>false</urPostInsecurely>
@@ -624,8 +624,8 @@ Options Element
         <natLeaseMinutes>60</natLeaseMinutes>
         <natRenewalMinutes>30</natRenewalMinutes>
         <natTimeoutSeconds>10</natTimeoutSeconds>
-        <urAccepted>-1</urAccepted>
-        <urSeen>3</urSeen>
+        <urAccepted>0</urAccepted>
+        <urSeen>0</urSeen>
         <urUniqueID></urUniqueID>
         <urURL>https://data.syncthing.net/newdata</urURL>
         <urPostInsecurely>false</urPostInsecurely>


### PR DESCRIPTION
The items urAccepted and urSeen were set to wrong values by mistake by
the commit 401060e978b77073485752749c7c0c38ea935a62. Both should be set
to "0" by default, indicating the default state before accepting or
rejecting to submit anonymous usage data.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>