### PR TITLE
users/config: Remove Windows XP info and fix LOCALAPPDATA case

### DIFF
--- a/users/config.rst
+++ b/users/config.rst
@@ -10,8 +10,7 @@ Synopsis
 
     $HOME/.config/syncthing
     $HOME/Library/Application Support/Syncthing
-    %AppData%/Syncthing
-    %localappdata%/Syncthing
+    %LOCALAPPDATA%/Syncthing
 
 Description
 -----------
@@ -19,9 +18,9 @@ Description
 Syncthing uses a single directory to store configuration, crypto keys
 and index caches. The location defaults to ``$HOME/.config/syncthing``
 (Unix-like), ``$HOME/Library/Application Support/Syncthing`` (Mac),
-``%AppData%/Syncthing`` (Windows XP) or ``%LocalAppData%/Syncthing``
-(Windows 7+). It can be changed at runtime using the ``-home`` flag. In this
-directory the following files are located:
+or ``%LOCALAPPDATA%/Syncthing`` (Windows). It can be changed at runtime
+using the ``-home`` flag. In this directory the following files are 
+located:
 
 :file:`config.xml`
     The configuration file, in XML format.


### PR DESCRIPTION
Not only does Syncthing not support Windows XP, but also the current
versions do not even run on Windows older than 7. Thus, remove the lines
mentioning Windows XP, as leaving them could indicate official support,
which is not the case.

Also, the location of %LOCALAPPDATA%/Syncthing listed as "Windows 7+" is
technically incorrect, since Windows Vista also uses the same place to
store Syncthing files. However, the current versions of Syncthing do not
run under Windows Vista either, hence there is no reason to mention it
specifically.

In addition, change the environment variable LOCALAPPDATA to all
uppercase to match the notation used by Microsoft in the official
Windows documentation.

See: https://docs.microsoft.com/windows/deployment/usmt/usmt-recognized-environment-variables

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>