### PR TITLE
users/stdiscosrv: Add Apache Reverse Proxy config to the discosrv documentation

### DIFF
--- a/users/reverseproxy.rst
+++ b/users/reverseproxy.rst
@@ -24,6 +24,11 @@ GUI hosted on ``localhost:8384``.
 Apache
 ~~~~~~
 
+First of all, execute the following command to enable the Apache HTTP Proxy
+module: ``a2enmod proxy_http``.
+
+Then, you may add the following to your Apache httpd configuration:
+
 .. code-block:: apache
 
     ProxyPass /syncthing/ http://localhost:8384/

--- a/users/stdiscosrv.rst
+++ b/users/stdiscosrv.rst
@@ -219,8 +219,8 @@ Requirements
 - The "X-SSL-Cert" HTTP header must be passed through with the PEM-encoded
   client SSL certificate. This will be present in POST requests and may be empty
   in GET requests from clients. If you see syncthing-discosrv outputting
-  :code:`no certificates` when POSTs are issued on it, that's because the
-  proxy is not passing this header through.
+  :code:`no certificates` when receiving POST requests, that's because the proxy
+  is not passing this header through.
 - The proxy must request the client SSL certificate but not require it to be
   signed by a trusted CA.
 
@@ -311,7 +311,7 @@ configuration:
 For more details, see also the recommendations in the
 `Reverse Proxy Setup <https://docs.syncthing.net/users/reverseproxy.html>`__
 page. Note that that page is directed at setting up a proxy for the
-Syncthing WebUI. You should do the proper path and port adjustments to proxying
+Syncthing web UI. You should do the proper path and port adjustments to proxying
 the discovery server and your particular setup.
 
 

--- a/users/stdiscosrv.rst
+++ b/users/stdiscosrv.rst
@@ -205,20 +205,46 @@ allows:
 - Use of a subdomain name without requiring a port number added to the URL
 - Sharing an SSL certificate with multiple services on the same server
 
+Note that after this configuration, clients have to omit the :code`?id=...`
+parameter of the discovery server URL on their configuration. Client-side
+validation will be done by checking the visible proxy server's certificate.
+
 Requirements
 ^^^^^^^^^^^^
 
 - Run the discovery server using the -http flag  :code:`stdiscosrv -http`.
 - SSL certificate/key configured for the reverse proxy
-- The "X-Forwarded-For" http header must be passed through with the client's
+- The "X-Forwarded-For" HTTP header must be passed through with the client's
   real IP address
-- The "X-SSL-Cert" must be passed through with the PEM-encoded client SSL
-  certificate
+- The "X-SSL-Cert" HTTP header must be passed through with the PEM-encoded
+  client SSL certificate
 - The proxy must request the client SSL certificate but not require it to be
   signed by a trusted CA.
 
+Apache
+""""""
+Add the following lines to the configuration:
+
+.. code-block:: apache
+
+    SSLProxyEngine On
+    SSLVerifyClient optional_no_ca
+    # The following is required, otherwise syncthing-discosrv
+    # outputs 'no certificates' when a POST is issued on it
+    RequestHeader set X-SSL-Cert "%{SSL_CLIENT_CERT}s"
+    # Apparently the RemoteIPHeader directive is not really required.
+    # I couldn't understand why it is recommended for a simple reverse proxy
+    # with no other services in front.
+    # Using this would require using a2enmod remoteip
+    #RemoteIPHeader X-Forwarded-For
+
+See also the recommendations in the
+`Reverse Proxy Setup <https://docs.syncthing.net/users/reverseproxy.html>`__
+page.
+
+
 Nginx
-^^^^^
+"""""
 
 These three lines in the configuration take care of the last three requirements
 listed above:

--- a/users/stdiscosrv.rst
+++ b/users/stdiscosrv.rst
@@ -205,17 +205,22 @@ allows:
 - Use of a subdomain name without requiring a port number added to the URL
 - Sharing an SSL certificate with multiple services on the same server
 
-Note that after this configuration, **clients have to omit the** :code:`?id=...`
-**parameter from the discovery server URL on their configuration**. Client-side
-validation will be done by checking the visible proxy server's HTTPS certificate.
+Note that after this configuration, if the proxy uses a valid HTTPS
+certificate, **clients should omit the** :code:`?id=...` **parameter from the
+discovery server URL on their configuration**. Client-side validation will be
+done by checking the visible proxy server's HTTPS certificate. If, however, the
+proxy uses a self-signed or somehow invalid certificate, clients must still set
+the :code:`?id=...` parameter with the computed hash of the proxy's
+certificate. Using such setup is discouraged and is not covered in this page.
+Always favour using valid and widely recognised certificates.
 
 Requirements
 ^^^^^^^^^^^^
 
 - Run the discovery server using the -http flag: :code:`stdiscosrv -http`.
-- SSL certificate/key configured for the reverse proxy
+- SSL certificate/key configured for the reverse proxy.
 - The "X-Forwarded-For" HTTP header must be passed through with the client's
-  real IP address
+  real IP address.
 - The "X-SSL-Cert" HTTP header must be passed through with the PEM-encoded
   client SSL certificate. This will be present in POST requests and may be empty
   in GET requests from clients. If you see syncthing-discosrv outputting


### PR DESCRIPTION
I had a hard time figuring out how to configure Apache httpd, syncthing-discosrv, as well as the Syncthing clients to use a discovery server behind an httpd reverse proxy.

Although the documentation is good enough for serving the GUI behind a proxy, and probably for serving the discovery server behind an nginx proxy, it was not that easy for having it behind and httpd proxy.

Additionally, it was not clear to me at all that the `id=...` parameter should be omitted after this configuration.

This change tries to make these things explicit in the documentation so that others do not face the same problems I had.