### PR TITLE
specs: Add encryption token to BEP and untrusted

### DIFF
--- a/specs/bep-v1.rst
+++ b/specs/bep-v1.rst
@@ -213,6 +213,8 @@ protocol buffer message just as in the uncompressed case.
 Message Subtypes
 ----------------
 
+.. _cluster-config:
+
 Cluster Config
 ^^^^^^^^^^^^^^
 
@@ -258,6 +260,7 @@ Protocol Buffer Schema
         bool            introducer                 = 7;
         uint64          index_id                   = 8;
         bool            skip_introduction_removals = 9;
+        bytes           enc_pw_token               = 10;
     }
 
     enum Compression {
@@ -338,6 +341,12 @@ index data. See :ref:`deltaidx` for the usage of this field.
 The **skip introduction removals** field signifies if the remote device has
 opted to ignore introduction removals for the given device. This setting is
 copied across as we are being introduced to a new device.
+
+The **enc pw token** field contains a token derived from the password, that is
+used to encrypt data sent to this device. If the device is the same as the
+device sending the message, it signifies that the device itself has encrypted
+data that was encrypted with the given token. It is empty or missing if there is
+no encryption. See :ref:`untrusted` for details on the encryption scheme.
 
 Index and Index Update
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/specs/untrusted.rst
+++ b/specs/untrusted.rst
@@ -1,3 +1,5 @@
+.. _untrusted:
+
 Untrusted Device Encryption
 ===========================
 
@@ -69,6 +71,16 @@ appended to the nonce itself::
 
 The original file metadata descriptor is encrypted in the same manner and
 attached to the encrypted-file metadata.
+
+Devices sharing a folder need to use the same password.
+To ensure that a *password token* in the form of an arbitrary, but commonly
+known string encrypted using AES-SIV with the folder key is sent in the
+:ref:`cluster-config`::
+
+    passwordToken = AES-SIV("syncthing" + folderID, folderKey)
+
+Thus an encrypted device can verify all its connected devices use the same
+password comparing the encrypted token, without knowing the password itself.
 
 .. note::
 


### PR DESCRIPTION
This is a PR towards https://github.com/syncthing/docs/pull/480, not master.

This documents a token sent in cluster config to ensure all involved parties use the same password. The concept was introduced and discussed in https://forum.syncthing.net/t/latest-encrypted-devices-proposal-what-how/14164/49 and followup posts.

The implementation for the "core mechanism" is done (what little crypto there is and BEP changes), however handing that additional state and making it available to the rest api/user is still work in progress. 