### PR TITLE
users/autostart: Use more descriptive heading for Task Scheduler

### DIFF
--- a/users/autostart.rst
+++ b/users/autostart.rst
@@ -29,8 +29,8 @@ Other solutions:
 
 .. _autostart-windows-taskschd:
 
-Task Scheduler
-~~~~~~~~~~~~~~
+Run at user log on or at system startup using Task Scheduler
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Task Scheduler is a built-in administrative tool, which can be used to
 start Syncthing automatically either at user log on, or at system


### PR DESCRIPTION
Update the Task Scheduler heading to clearly describe what the following
configuration is all about. This goes in line with the current headings
for the Startup folder and the NSSM service configuration, which are
descriptive also.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>