### PR TITLE
users/autostart: Use more descriptive heading for third-party tools

### DIFF
--- a/users/autostart.rst
+++ b/users/autostart.rst
@@ -140,8 +140,8 @@ make selective use of them depending on your needs.
 
 .. _autostart-windows-tools:
 
-Third-party Tools
-~~~~~~~~~~~~~~~~~
+Install and run using third-party tools
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 There are a number of third-party utilities which aim to address this
 issue. These typically provide an installer, let Syncthing start


### PR DESCRIPTION
Update the third-party tools heading to be more descriptive about what
they are used for. This goes in line with the current headings for the
Startup folder and the NSSM service configuration, which are descriptive
also.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>