### PR TITLE
Fix for systemd user services on Debian/Ubuntu

### DIFF
--- a/users/autostart.rst
+++ b/users/autostart.rst
@@ -391,6 +391,10 @@ How to set up a user service
 
     systemctl --user enable syncthing.service
     systemctl --user start syncthing.service
+#. If your home directory is encrypted with eCryptfs on Debian/Ubuntu, then you will need to make
+   the change described in `Ubuntu bug 1734290 <https://bugs.launchpad.net/ecryptfs/+bug/1734290>`__.
+   Otherwise the user service will not start, because by default, systemd checks for user
+   services before your home directory has been decrypted.
 
 Checking the service status
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The default PAM configuration on Debian/Ubuntu has systemd check for user services before cryptfs has decrypted the home directory, so Syncthing does not run as a user service. https://bugs.launchpad.net/ecryptfs/+bug/1734290 describes how to change the PAM configuration to fix this.