### PR TITLE
users/autostart: Remove outdated page warning (fixes #523)

### DIFF
--- a/users/autostart.rst
+++ b/users/autostart.rst
@@ -1,9 +1,6 @@
 Starting Syncthing Automatically
 ================================
 
-.. warning::
-  This page may be outdated and requires review.
-
 Jump to configuration for your system:
 
 - `Windows <#windows>`__


### PR DESCRIPTION
Remove the red warning about the page being outdated and requiring
review. The page has been updated when needed, and contains valid
information about setting Syncthing up to start automatically in various
operating systems. The warning gives a false idea that the information
presented here is not relevant.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>