### PR TITLE
users/crashrep: Add note about using custom builds of Syncthing

### DIFF
--- a/users/crashrep.rst
+++ b/users/crashrep.rst
@@ -39,12 +39,11 @@ The following is an example of a crash report as sent::
     main.syncthingMain(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x49651b4, 0x1, 0x0, 0x0, ...)
             /buildagent/work/github.com/syncthing/syncthing/cmd/syncthing/main.go:873 +0x1bc5
 
-Note that when using a custom compiled build, the names of the domain,
-computer, and user of the machine where Syncthing was built will be
-included in the log as part of the version string. This information is
-essential for the developers to interpret the crash log in context. If
-you compile Synching locally and want to prevent your build from having
-such data embedded, set the ``COMPUTERNAME``, ``USERDOMAIN``, and
-``USERNAME`` variables to ``unknown`` before the compilation.
+
+Note that the username and hostname of the machine where Syncthing was
+built will be included in the crash log as part of the version string.
+This information is essential for the developers to interpret the log in
+context. If you compile Syncthing locally and want to prevent your build
+from having such data embedded, see :ref:`versiontagging`.
 
 For a more details description of the format and how the sending happens, see :ref:`crashrep-dev`.

--- a/users/crashrep.rst
+++ b/users/crashrep.rst
@@ -40,10 +40,11 @@ The following is an example of a crash report as sent::
             /buildagent/work/github.com/syncthing/syncthing/cmd/syncthing/main.go:873 +0x1bc5
 
 Note that when using a custom compiled build, the names of the domain,
-computer, and user of the machine where Syncthing was built will also
-be included in the log. If you compile Syncthing locally and want to
-prevent this kind of information from being recorded in the build, set
-the ``COMPUTERNAME``, ``USERDOMAIN``, and ``USERNAME`` variables to
-``unknown`` before the compilation.
+computer, and user of the machine where Syncthing was built are included
+in the log as part of the version string. This information is essential
+for the developers to interpret the crash log in context. If you compile
+Synching locally and want to prevent your build from having such data
+embedded, set the ``COMPUTERNAME``, ``USERDOMAIN``, and ``USERNAME``
+variables to ``unknown`` before the compilation.
 
 For a more details description of the format and how the sending happens, see :ref:`crashrep-dev`.

--- a/users/crashrep.rst
+++ b/users/crashrep.rst
@@ -39,4 +39,9 @@ The following is an example of a crash report as sent::
     main.syncthingMain(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x49651b4, 0x1, 0x0, 0x0, ...)
             /buildagent/work/github.com/syncthing/syncthing/cmd/syncthing/main.go:873 +0x1bc5
 
+Note that when using a custom compiled build of Syncthing, the names of
+your computer, domain, and user will also be included in the log. To
+prevent this, set the ``COMPUTERNAME``, ``USERDOMAIN``, and ``USERNAME``
+variables to ``unknown`` when compiling Syncthing locally.
+
 For a more details description of the format and how the sending happens, see :ref:`crashrep-dev`.

--- a/users/crashrep.rst
+++ b/users/crashrep.rst
@@ -39,9 +39,11 @@ The following is an example of a crash report as sent::
     main.syncthingMain(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x49651b4, 0x1, 0x0, 0x0, ...)
             /buildagent/work/github.com/syncthing/syncthing/cmd/syncthing/main.go:873 +0x1bc5
 
-Note that when using a custom compiled build of Syncthing, the names of
-your computer, domain, and user will also be included in the log. To
-prevent this, set the ``COMPUTERNAME``, ``USERDOMAIN``, and ``USERNAME``
-variables to ``unknown`` when compiling Syncthing locally.
+Note that when using a custom compiled build, the names of the domain,
+computer, and user of the machine where Syncthing was built will also
+be included in the log. If you compile Syncthing locally and want to
+prevent this kind of information from being recorded in the build, set
+the ``COMPUTERNAME``, ``USERDOMAIN``, and ``USERNAME`` variables to
+``unknown`` before the compilation.
 
 For a more details description of the format and how the sending happens, see :ref:`crashrep-dev`.

--- a/users/crashrep.rst
+++ b/users/crashrep.rst
@@ -40,11 +40,11 @@ The following is an example of a crash report as sent::
             /buildagent/work/github.com/syncthing/syncthing/cmd/syncthing/main.go:873 +0x1bc5
 
 Note that when using a custom compiled build, the names of the domain,
-computer, and user of the machine where Syncthing was built are included
-in the log as part of the version string. This information is essential
-for the developers to interpret the crash log in context. If you compile
-Synching locally and want to prevent your build from having such data
-embedded, set the ``COMPUTERNAME``, ``USERDOMAIN``, and ``USERNAME``
-variables to ``unknown`` before the compilation.
+computer, and user of the machine where Syncthing was built will be
+included in the log as part of the version string. This information is
+essential for the developers to interpret the crash log in context. If
+you compile Synching locally and want to prevent your build from having
+such data embedded, set the ``COMPUTERNAME``, ``USERDOMAIN``, and
+``USERNAME`` variables to ``unknown`` before the compilation.
 
 For a more details description of the format and how the sending happens, see :ref:`crashrep-dev`.


### PR DESCRIPTION
Add a note explaining the inclusion of information such as the user's
computer, domain, and user name in the crash logs. Also, provide a
solution on how not to include those when building Syncthing locally.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>