### PR TITLE
dev/building: Use md, and quotes in paths in Windows

### DIFF
--- a/dev/building.rst
+++ b/dev/building.rst
@@ -82,8 +82,8 @@ Building (Windows)
     > go version
 
     # Pick a place for your Syncthing source.
-    > mkdir %USERPROFILE%\dev
-    > cd %USERPROFILE%\dev
+    > md "%USERPROFILE%\dev"
+    > cd "%USERPROFILE%\dev"
 
     # Grab the code.
     > git clone https://github.com/syncthing/syncthing.git


### PR DESCRIPTION
Use "md" instead of "mkdir", because it is shorter. Also, use quotations
for the USERPROFILE path, as otherwise the command will fail when the
username has spaces in it.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>