### PR TITLE
all: Fix Microsoft-related URLs

### DIFF
--- a/dev/debugging.rst
+++ b/dev/debugging.rst
@@ -46,6 +46,6 @@ Follow these steps:
 
 For installing and using delve itself see:
 
--  VSCode (Microsoft): https://github.com/Microsoft/vscode-go/wiki/Debugging-Go-code-using-VS-Code
+-  VSCode (Microsoft): https://github.com/golang/vscode-go/blob/master/docs/debugging.md
 
 -  Goland (JetBrains): create remote run configuration and follow the two steps displayed

--- a/users/faq.rst
+++ b/users/faq.rst
@@ -341,7 +341,7 @@ If only your remote computer is Unix-like,
 you can still access it with ssh from Windows.
 
 Under Windows 10 (64 bit) you can use the same ssh command if you install
-the `Windows Subsystem for Linux <https://docs.microsoft.com/en-gb/windows/wsl/install-win10>`__.
+the `Windows Subsystem for Linux <https://docs.microsoft.com/windows/wsl/install-win10>`__.
 
 Another Windows way to run ssh is to install `gow (Gnu On Windows) <https://github.com/bmatzelle/gow>`__. The easiest way to install gow is with the `chocolatey <https://chocolatey.org/>`__ package manager.
 


### PR DESCRIPTION
Fix a moved VSCode URL, and use a language-agnostic URL for WSL.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>