### PR TITLE
typo fix in code: addresd->address

### DIFF
--- a/rest/system-config-get.rst
+++ b/rest/system-config-get.rst
@@ -96,7 +96,7 @@ Returns the current configuration.
 	"insecureAllowFrameLoading": false
       },
       "ldap": {
-	"addresd": "",
+	"address": "",
 	"bindDN": "",
 	"transport": "plain",
 	"insecureSkipVerify": false


### PR DESCRIPTION
This PR changes `addresd` to `address` in the LDAP section of the config in `rest/system-config-get.rst`.

This PR is submitted separately from its nearby sibling #545, because it should be checked much more carefully than the other prose changes.

In particular, I *think* the name should be `address`, but was not 100% sure if it should be unchanged, or `addressd` or `address`.  Hence, out of an abundance of caution, I made a separate PR.

I believe the two sibling PRs can be merged in either order -- this PR should not conflict with #545.