### PR TITLE
refresh-authors: Escape underscores in thanks.txt

### DIFF
--- a/refresh-authors.sh
+++ b/refresh-authors.sh
@@ -8,7 +8,4 @@ grep \# AUTHORS > authors-hdr
 cat authors-hdr authors-new > AUTHORS
 rm authors-hdr authors-new
 
-git contributors --read-authors=AUTHORS --names --geekrank > thanks.txt
-
-# Underscores need be escaped in RST.
-sed -i '/_/ s//\\_/g' thanks.txt
+git contributors --read-authors=AUTHORS --names --geekrank | sed 's/_/\\_/g' > thanks.txt

--- a/refresh-authors.sh
+++ b/refresh-authors.sh
@@ -10,3 +10,5 @@ rm authors-hdr authors-new
 
 git contributors --read-authors=AUTHORS --names --geekrank > thanks.txt
 
+# Underscores need be escaped in RST.
+sed -i '/_/ s//\\_/g' thanks.txt


### PR DESCRIPTION
Underscores need be escaped in RST. If not, the words containing them
are later transformed into links in the HTML.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>