### PR TITLE
users/config: Clarify config and GUI input difference for listen address

### DIFF
--- a/users/config.rst
+++ b/users/config.rst
@@ -872,7 +872,7 @@ setLowPriority
 Listen Addresses
 ^^^^^^^^^^^^^^^^
 
-The following address types are accepted in sync protocol listen addresses. If you want Syncthing to listen on multiple addresses, you can have multiple ``<listenAddress>`` tags. The same is achieved in the GUI by entering several addresses separated by comma.
+The following address types are accepted in sync protocol listen addresses. If you want Syncthing to listen on multiple addresses, you can either: add multiple ``<listenAddress>`` tags in the configuration file or enter several addresses separated by commas in the GUI.
 
 Default listen addresses (``default``)
     This is equivalent to ``tcp://0.0.0.0:22000``, ``quic://0.0.0.0:22000``


### PR DESCRIPTION
Clarifies that configuration files should use multiple XML tags rather
than a command seperated list which is GUI specific.

This caught me out earlier after following the docs and required some digging through the forums to figure it out.