### PR TITLE
rest: Document new /rest/config endpoints

### DIFF
--- a/dev/rest.rst
+++ b/dev/rest.rst
@@ -27,6 +27,14 @@ System Endpoints
 
    ../rest/system-*
 
+Config Endpoints
+----------------
+
+.. toctree::
+   :maxdepth: 1
+
+   /rest/config/... <../rest/config.rst>
+
 Database Endpoints
 ------------------
 

--- a/rest/config.rst
+++ b/rest/config.rst
@@ -1,0 +1,57 @@
+Config Endpoints
+================
+
+These endpoints facilitate access and modification of the :ref:`configuration
+<config>` in a granular way. Config sent to the endpoints must be in the same
+format as returned by the corresponding GET request. When posting the
+configuration succeeds, the posted configuration is immediately applied, except
+for changes that require a restart. Query :ref:`rest-config-insync` to check if
+a restart is required.
+
+For all endpoints supporting ``PATCH``, it takes the existing config and
+unmarshals the given JSON object on top of it. This means all child objects will
+replace the existing objects, not extend them. For example for
+``RawListenAddresses` in options, which is an array of strings, sending
+``{RawListenAddresses: ["tcp://10.0.0.2"]`` will replace all existing listen
+addresses.
+
+.. note::
+   Changing config in quick succession can be problematic. The changes may not
+   be applied in order, which might change the outcome. It is advicabable to
+   prevent too frequent config changes and/or check that changes were applied as
+   desired.
+
+.. _rest-config:
+
+/rest/config
+------------
+
+``GET`` returns the entire config and ``PUT`` replaces it.
+
+.. _rest-config-insync:
+
+/rest/system/config/insync
+--------------------------
+
+``GET`` returns whether the config is in sync, i.e. whether the running configuration is
+the same as that on disk or if a restart is required.
+
+/rest/config/folders, /rest/config/devices
+------------------------------------------
+
+``GET`` returns all folders respectively devices as an array. ``PUT`` takes an array and
+``POST`` a single object. In both cases if a given folder/device already exists,
+it's replaced, otherwise a new one is added.
+
+/rest/config/folders/\*id\*, /rest/config/devices/\*id\*
+--------------------------------------------------------
+
+Put the desired folder- respectively device-ID in place of \*id\*. ``GET``
+returns the folder/device for the given ID, ``PUT`` replaces the entire config
+and ``PATCH`` replaces only the given child objects.
+
+/rest/config/options, /rest/config/ldap, /rest/config/gui
+---------------------------------------------------------
+
+``GET`` returns the respective object, ``PUT`` replaces the entire object and
+``PATCH`` replaces only the given child objects.

--- a/rest/config.rst
+++ b/rest/config.rst
@@ -1,6 +1,8 @@
 Config Endpoints
 ================
 
+.. versionadded:: 1.12.0
+
 These endpoints facilitate access and modification of the :ref:`configuration
 <config>` in a granular way. Config sent to the endpoints must be in the same
 format as returned by the corresponding GET request. When posting the
@@ -14,12 +16,6 @@ replace the existing objects, not extend them. For example for
 ``RawListenAddresses` in options, which is an array of strings, sending
 ``{RawListenAddresses: ["tcp://10.0.0.2"]`` will replace all existing listen
 addresses.
-
-.. note::
-   Changing config in quick succession can be problematic. The changes may not
-   be applied in order, which might change the outcome. It is advicabable to
-   prevent too frequent config changes and/or check that changes were applied as
-   desired.
 
 .. _rest-config:
 

--- a/rest/system-config-get.rst
+++ b/rest/system-config-get.rst
@@ -1,6 +1,10 @@
 GET /rest/system/config
 =======================
 
+.. deprecated:: v1.12.0
+   This endpoint still works as before but is deprecated. Use :ref:`rest-config`
+   instead.
+
 Returns the current configuration.
 
 .. code-block:: json

--- a/rest/system-config-insync-get.rst
+++ b/rest/system-config-insync-get.rst
@@ -1,7 +1,9 @@
-.. _rest-config-insync:
-
 GET /rest/system/config/insync
 ==============================
+
+.. deprecated:: v1.12.0
+   This endpoint still works as before but is deprecated. Use
+   :ref:`rest-config-insync` instead.
 
 Returns whether the config is in sync, i.e. whether the running
 configuration is the same as that on disk.

--- a/rest/system-config-post.rst
+++ b/rest/system-config-post.rst
@@ -1,6 +1,10 @@
 POST /rest/system/config
 ========================
 
+.. deprecated:: v1.12.0
+   This endpoint still works as before but is deprecated. Use :ref:`rest-config`
+   instead.
+
 Post the full contents of the configuration, in the same format as returned by
 the corresponding GET request. When posting the configuration succeeds,
 the posted configuration is immediately applied, except for changes that require a restart. Query


### PR DESCRIPTION
Documents https://github.com/syncthing/syncthing/pull/7001

The descriptions of the different endpoints are a bit repetitive, even after collecting similar ones together. The main purpose is to mention all available endpoints and which methods they support. Maybe just enlisting all the options as keywords, without actual text would do just as well (?).

I purposely didn't include any examples: Those are just bound to get out-of-date and the user may as well just try it out to see what it looks like.