### PR TITLE
users: Fix outdate info about monitor and device-ids

### DIFF
--- a/includes/env-vars.rst
+++ b/includes/env-vars.rst
@@ -95,9 +95,7 @@ STNODEFAULTFOLDER
     variable will be ignored anytime after the first run.
 
 STNORESTART
-    Equivalent to the ``-no-restart`` flag. Disable the Syncthing monitor
-    process which handles restarts for some configuration changes, upgrades,
-    crashes and also log file writing (stdout is still written).
+    Equivalent to the ``-no-restart`` flag
 
 STNOUPGRADE
     Disable automatic upgrades.

--- a/users/config.rst
+++ b/users/config.rst
@@ -426,8 +426,7 @@ it is not present. The following attributes may be set on the ``device``
 element:
 
 id
-    The device ID. This must be written in canonical form, that is without any
-    spaces or dashes. (mandatory)
+    The :ref:`device ID <device-ids>`. (mandatory)
 
 name
     A friendly name for the device. (optional)

--- a/users/syncthing.rst
+++ b/users/syncthing.rst
@@ -36,7 +36,8 @@ Options
 
 .. cmdoption:: -auditfile=<file|-|-->
 
-    Use specified file or stream (``"-"`` for stdout, ``"--"`` for stderr) for audit events, rather than the timestamped default file name.
+    Use specified file or stream (``"-"`` for stdout, ``"--"`` for stderr) for
+    audit events, rather than the timestamped default file name.
 
 .. cmdoption:: -browser-only
 
@@ -74,7 +75,8 @@ Options
 
 .. cmdoption:: -logfile=<filename>
 
-    Set destination filename for logging (use ``"-"`` for stdout, which is the default option).
+    Set destination filename for logging (use ``"-"`` for stdout, which is the
+    default option).
 
 .. cmdoption:: -logflags=<flags>
 
@@ -101,11 +103,13 @@ Options
 
 .. cmdoption:: -no-restart
 
-    Disable the Syncthing monitor process which handles restarts for some configuration changes, upgrades, crashes and also log file writing (stdout is still written).
+    Do not restart Syncthing when it exits. The monitor process will still run
+    to handle crashes and writing to logfiles (if configured to).
 
 .. cmdoption:: -paths
 
-    Print the paths used for configuration, keys, database, GUI overrides, default sync folder and the log file.
+    Print the paths used for configuration, keys, database, GUI overrides,
+    default sync folder and the log file.
 
 .. cmdoption:: -paused
 
@@ -161,11 +165,9 @@ Exit Codes
 4
     Upgrading
 
-Some of these exit codes are only returned when running without a monitor
-process (with environment variable ``STNORESTART`` set). Exit codes over 125 are
-usually returned by the shell/binary loader/default signal handler. Exit codes
-over 128+N on Unix usually represent the signal which caused the process to
-exit. For example, ``128 + 9 (SIGKILL) = 137``.
+Exit codes over 125 are usually returned by the shell/binary loader/default
+signal handler. Exit codes over 128+N on Unix usually represent the signal which
+caused the process to exit. For example, ``128 + 9 (SIGKILL) = 137``.
 
 Proxies
 -------


### PR DESCRIPTION
Removed/changed some outdated information. And added line breaks, which are necessary there as the text is used for manpages and they don't wrap.