### PR TITLE
users/autostart: Add warning about ending task in Task Scheduler (fixes #577)

### DIFF
--- a/users/autostart.rst
+++ b/users/autostart.rst
@@ -135,6 +135,12 @@ make selective use of them depending on your needs.
 
    |Windows Task Scheduler Additional Actions Screenshot|
 
+.. warning::
+  Due to technical limitations, ending the task in Task Scheduler
+  terminates only the monitor process of Syncthing. In order to actually
+  exit Syncthing, open the Web GUI and press the "Shutdown" button under
+  the "Actions" dropdown menu.
+
 .. _autostart-windows-startup:
 
 Run at user log on using the Startup folder


### PR DESCRIPTION
Add a warning about the impossibility of exiting Syncthing using the
"end task" functionality in Task Scheduler. Ending the task only stops
the parent-monitor process of Syncthing, and leaves its child process
untouched. This makes the user believe that Syncthing is no longer
running, while in reality the child process is still operating in
background.

Since there is no way to fix or work around the problem using Task
Scheduler itself, add a warning at end of the instructions to inform
the users about these limitations.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>