### PR TITLE
users/config: Improve modTimeWindowS explanation

### DIFF
--- a/users/config.rst
+++ b/users/config.rst
@@ -354,9 +354,12 @@ copyOwnershipFromParent
     Requires running Syncthing as privileged user, or granting it additional capabilities (e.g. CAP_CHOWN on Linux).
 
 modTimeWindowS
-    Allowed modification timestamp difference when comparing files for equivalence.
-    To be used on systems that have unstable modification timestamps, that might change after being observed after
-    the last write operation. Used in Android only.
+    Allowed modification timestamp difference when comparing files for
+    equivalence. To be used on file systems which have unstable or
+    imprecise modification timestamps (e.g. FAT) that might change after
+    being recorded during the last write operation. Must be set before
+    adding files to the folder in order to take effect. Usually defaults
+    to 2 on Android, and always to 0 elsewhere.
 
 maxConcurrentWrites
     Maximum number of concurrent write operations while syncing. Defaults to 2. Increasing this might increase or

--- a/users/config.rst
+++ b/users/config.rst
@@ -356,10 +356,10 @@ copyOwnershipFromParent
 modTimeWindowS
     Allowed modification timestamp difference when comparing files for
     equivalence. To be used on file systems which have unstable or
-    imprecise modification timestamps (e.g. FAT) that might change after
-    being recorded during the last write operation. Must be set before
-    adding files to the folder in order to take effect. Usually defaults
-    to 2 on Android, and always to 0 elsewhere.
+    imprecise modification timestamps that might change after being
+    recorded during the last write operation. Defaults to 2 on Android
+    when the folder is located on a FAT partition, and always to 0
+    elsewhere.
 
 maxConcurrentWrites
     Maximum number of concurrent write operations while syncing. Defaults to 2. Increasing this might increase or

--- a/users/config.rst
+++ b/users/config.rst
@@ -355,11 +355,10 @@ copyOwnershipFromParent
 
 modTimeWindowS
     Allowed modification timestamp difference when comparing files for
-    equivalence. To be used on file systems which have unstable or
-    imprecise modification timestamps that might change after being
-    recorded during the last write operation. Defaults to 2 on Android
-    when the folder is located on a FAT partition, and always to 0
-    elsewhere.
+    equivalence. To be used on file systems which have unstable
+    modification timestamps that might change after being recorded
+    during the last write operation. Defaults to 2 on Android when the
+    folder is located on a FAT partition, and always to 0 elsewhere.
 
 maxConcurrentWrites
     Maximum number of concurrent write operations while syncing. Defaults to 2. Increasing this might increase or


### PR DESCRIPTION
Reword the explanation to make it more specific. Add an example of a
file system (FAT), where the setting is applicable. Add a warning about
the necessecity of setting the value before adding files to the folder.
Explicitly mention the default values depending on the OS.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>