### PR TITLE
users/contrib: Add Syncthing-Fork to Community Contributions

### DIFF
--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -26,6 +26,11 @@ Android
 
   A wrapper app for the Syncthing binary.
 
+- `Syncthing-Fork <https://github.com/catfriend1/syncthing-android>`_
+
+  An alternative wrapper app for the Syncthing binary with extended
+  functionality.
+
 - `syncthing-lite <https://github.com/syncthing/syncthing-lite>`_
 
   Down- or uploads data from accessible devices, does not continuously keep a


### PR DESCRIPTION
Syncthing-Fork is a fork of the official Android application with added
functionality. It has existed for a few years now, and is also actively
maintained and frequently updated. As such, it should be listed under
the Community Contributions.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>