### PR TITLE
users/contrib: Move Syncthing Lite to unmaintained projects (fixes #586)

### DIFF
--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -31,11 +31,6 @@ Android
   An alternative wrapper app for the Syncthing binary with extended
   functionality.
 
-- `syncthing-lite <https://github.com/syncthing/syncthing-lite>`_
-
-  Down- or uploads data from accessible devices, does not continuously keep a
-  share in sync.
-
 .. _contrib-windows:
 
 Windows
@@ -239,6 +234,7 @@ Older, Possibly Unmaintained
    these and you have revived the project, please update this page
    accordingly.
 
+-  https://github.com/syncthing/syncthing-lite
 -  https://github.com/sieren/QSyncthingTray
 -  https://github.com/akissa/pysyncthing
 -  https://github.com/retgoat/syncthing-ruby


### PR DESCRIPTION
Syncthing Lite has not been updated for a long time, and its repository
has also been archived. Unless someone decides to step up and continue
working on it, it should be moved to the unmaintained projects list for
now, especially since it does not seem to be functional in its current
state.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>