### PR TITLE
css: Add margins between list items with paragraphs

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -58,3 +58,11 @@ div.admonition p.admonition-title {
 p.admonition-title:after {
   content: none;
 }
+
+/* Override Alabaster theme defaults to add space between list items. */
+li > p:last-child {
+  margin-bottom: 1em;
+}
+li:last-child > p:last-child {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
The default theme removes margins after last paragraph inside a list
item, but this removes any space between two adjacent list items. Thus,
override the default CSS keeping the default margin of 1em, and only
remove the margin in the last list item instead.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>