### PR TITLE
users/ignoring: Add info about trimming leading and trailing spaces

### DIFF
--- a/users/ignoring.rst
+++ b/users/ignoring.rst
@@ -36,7 +36,8 @@ The ``.stignore`` file contains a list of file or path patterns. The
 
 -  Regular file names match themselves, i.e. the pattern ``foo`` matches
    the files ``foo``, ``subdir/foo`` as well as any directory named
-   ``foo``. Spaces are treated as regular characters.
+   ``foo``. Spaces are treated as regular characters, except for leading
+   and trailing spaces, which are automatically trimmed.
 
 -  **Asterisk** (``*``) matches zero or more characters in a filename, but does not
    match the directory separator. ``te*ne`` matches ``telephone``,


### PR DESCRIPTION
Explicitly note that leading and trailing spaces are automatically
trimmed from ignore patterns.

Ref: https://github.com/syncthing/syncthing/issues/7228

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>