### PR TITLE
events: Add PendingDevicesChanged and PendingFoldersChanged (ref #592)

### DIFF
--- a/events/devicerejected.rst
+++ b/events/devicerejected.rst
@@ -1,6 +1,10 @@
 DeviceRejected
 --------------
 
+.. deprecated:: v1.13.0
+   This event is still emitted for compatibility, but deprecated.  Use
+   the replacement :ref:`pending-devices-changed` event instead.
+
 Emitted when there is a connection from a device we are not configured
 to talk to.
 

--- a/events/folderrejected.rst
+++ b/events/folderrejected.rst
@@ -1,6 +1,10 @@
 FolderRejected
 --------------
 
+.. deprecated:: v1.13.0
+   This event is still emitted for compatibility, but deprecated.  Use
+   the replacement :ref:`pending-folders-changed` event instead.
+
 Emitted when a device sends index information for a folder we do not
 have, or have but do not share with the device in question.
 

--- a/events/pendingdeviceschanged.rst
+++ b/events/pendingdeviceschanged.rst
@@ -3,6 +3,8 @@
 PendingDevicesChanged
 ---------------------
 
+.. versionadded:: 1.14.0
+
 Emitted when pending devices were added / updated (connection from
 unknown ID) or removed (device is ignored or added).
 

--- a/events/pendingdeviceschanged.rst
+++ b/events/pendingdeviceschanged.rst
@@ -1,0 +1,27 @@
+PendingDevicesChanged
+---------------------
+
+Emitted when pending devices were added / updated (connection from
+unknown ID) or removed (device is ignored or added).
+
+.. code-block:: json
+
+    {
+      "id": 87,
+      "type": "PendingDevicesChanged",
+      "time": "2020-12-22T22:24:37.578586718+01:00",
+      "data": {
+	"added": [
+	  {
+	    "address": "127.0.0.1:51807",
+	    "device": "EJHMPAQ-OGCVORE-ISB4IS3-SYYVJXF-TKJGLTU-66DIQPF-GJ5D2GX-GQ3OWQK",
+	    "name": "My dusty computer"
+	  }
+	],
+	"removed": [
+	  {
+	    "device": "P56IOI7-MZJNU2Y-IQGDREY-DM2MGTI-MGL3BXN-PQ6W5BM-TBBZ4TJ-XZWICQ2"
+	  }
+	]
+      }
+    }

--- a/events/pendingdeviceschanged.rst
+++ b/events/pendingdeviceschanged.rst
@@ -1,3 +1,5 @@
+.. _pending-devices-changed:
+
 PendingDevicesChanged
 ---------------------
 

--- a/events/pendingfolderschanged.rst
+++ b/events/pendingfolderschanged.rst
@@ -1,3 +1,5 @@
+.. _pending-folders-changed:
+
 PendingFoldersChanged
 ---------------------
 

--- a/events/pendingfolderschanged.rst
+++ b/events/pendingfolderschanged.rst
@@ -3,6 +3,8 @@
 PendingFoldersChanged
 ---------------------
 
+.. versionadded:: 1.14.0
+
 Emitted when pending folders were added / updated (offered by some
 device, but not shared to them) or removed (folder ignored or added or
 no longer offered from the remote device).

--- a/events/pendingfolderschanged.rst
+++ b/events/pendingfolderschanged.rst
@@ -1,0 +1,29 @@
+PendingFoldersChanged
+---------------------
+
+Emitted when pending folders were added / updated (offered by some
+device, but not shared to them) or removed (folder ignored or added or
+no longer offered from the remote device).
+
+.. code-block:: json
+
+    {
+      "id": 101,
+      "type": "PendingFoldersChanged",
+      "time": "2020-12-22T22:36:55.66744317+01:00",
+      "data": {
+	"added": [
+	  {
+	    "device": "EJHMPAQ-OGCVORE-ISB4IS3-SYYVJXF-TKJGLTU-66DIQPF-GJ5D2GX-GQ3OWQK",
+	    "folder": "GXWxf-3zgnU",
+	    "folderLabel": "My Pictures"
+	  }
+	],
+	"removed": [
+	  {
+	    "device": "P56IOI7-MZJNU2Y-IQGDREY-DM2MGTI-MGL3BXN-PQ6W5BM-TBBZ4TJ-XZWICQ2",
+	    "folder": "neyfh-sa2nu"
+	  }
+	]
+      }
+    }


### PR DESCRIPTION
Correlated to syncthing/syncthing#7205.

The previous DeviceRejected and FolderRejected events are marked as deprecated with a hint linking to the new events.