### PR TITLE
users/config: Document decoupled database + config (fixes #571)

### DIFF
--- a/users/config.rst
+++ b/users/config.rst
@@ -15,11 +15,17 @@ Synopsis
 Description
 -----------
 
-Syncthing uses a single directory to store configuration, crypto keys
-and index caches. The location defaults to ``$HOME/.config/syncthing``
+.. versionadded:: 1.5.0
+
+    Database and config can now be set separately. Previously the database was
+    always located in the same directory as the config.
+
+Syncthing uses a single directory to store configuration and crypto keys.
+Syncthing also has a database, which is often stored in this directory too.
+The config location defaults to ``$HOME/.config/syncthing``
 (Unix-like), ``$HOME/Library/Application Support/Syncthing`` (Mac),
 or ``%LOCALAPPDATA%/Syncthing`` (Windows). It can be changed at runtime
-using the ``-home`` flag. In this directory the following files are
+using the ``-config`` flag. In this directory the following files are
 located:
 
 :file:`config.xml`
@@ -33,13 +39,27 @@ located:
     The certificate and key for HTTPS GUI connections. These may be replaced
     with a custom certificate for HTTPS as desired.
 
-:file:`index-{*}.db`
-    A directory holding the database with metadata and hashes of the files
-    currently on disk and available from peers.
-
 :file:`csrftokens.txt`
     A list of recently issued CSRF tokens (for protection against browser cross
     site request forgery).
+
+The database is stored either in the same directory as the config (usually the
+default), but may also be located in one of the following directories (Unix-like 
+platforms only):
+
+* If a database exists in the old default location, that location is
+  still used.
+* If ``$XDG_DATA_HOME`` is set, use ``$XDG_DATA_HOME/syncthing``.
+* If ``~/.local/share/syncthing`` exists, use that location.
+* Use the old default location (same as config).
+
+The location of the database can be changed using the ``-data`` flag. The
+``-home`` flag sets both config and database locations at the same time.
+The database contains the following files:
+
+:file:`index-{*}.db`
+    A directory holding the database with metadata and hashes of the files
+    currently on disk and available from peers.
 
 Config File Format
 ------------------


### PR DESCRIPTION
Finally remembered that I had this still open. Since the change is already kinda ancient (v1.5.0) I was unsure about adding a "new in version..." header, but we have that thing for other ancient things too...