### PR TITLE
users/config: Use backslashes in Windows paths

### DIFF
--- a/users/config.rst
+++ b/users/config.rst
@@ -10,7 +10,7 @@ Synopsis
 
     $HOME/.config/syncthing
     $HOME/Library/Application Support/Syncthing
-    %LOCALAPPDATA%/Syncthing
+    %LOCALAPPDATA%\Syncthing
 
 Description
 -----------
@@ -24,7 +24,7 @@ Syncthing uses a single directory to store configuration and crypto keys.
 Syncthing also has a database, which is often stored in this directory too.
 The config location defaults to ``$HOME/.config/syncthing``
 (Unix-like), ``$HOME/Library/Application Support/Syncthing`` (Mac),
-or ``%LOCALAPPDATA%/Syncthing`` (Windows). It can be changed at runtime
+or ``%LOCALAPPDATA%\Syncthing`` (Windows). It can be changed at runtime
 using the ``-config`` flag. In this directory the following files are
 located:
 


### PR DESCRIPTION
Change the currently used forward slashes to backslahes in Windows
paths.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>