### PR TITLE
users/faq: Add a warning about mixing nested folders with Introducer

### DIFF
--- a/users/faq-parts/usage.rst
+++ b/users/faq-parts/usage.rst
@@ -27,11 +27,16 @@ See the previous question.
 Am I able to nest shared folders in Syncthing?
 ----------------------------------------------
 
-Sharing a folder that is within an already shared folder is possible, but it has
-its caveats. What you must absolutely avoid are circular shares. This is just
-one example, there may be other undesired effects. Nesting shared folders is not
-supported, recommended or coded for, but it can be done successfully when you
-know what you're doing - you have been warned.
+Sharing a folder that is within an already shared folder is possible,
+but it has its caveats. What you must absolutely avoid are circular
+shares. You should also be careful when using :ref:`introducer`, which
+can lead to sharing both the nested folder and its parent between the
+same devices. These are just two examples, there may be other undesired
+effects. Nesting shared folders is not supported, recommended or coded
+for, but it can be done successfully when you know what you're doing -
+you have been warned.
+
+
 
 How do I rename/move a synced folder?
 -------------------------------------


### PR DESCRIPTION
Add a warning to the FAQ about using the Introducer feature together
with nested folders, as that can lead to Syncthing automatically sharing
both the nested folder itself and its parent between the same devices.

Even though Syncthing can deal with such situations and still properly
synchronise the files, it leads to an unnecessary overhead and creates
temporary files, which hang around for 24 hours (by default) for no
purpose.

Ref: https://github.com/syncthing/syncthing/issues/7338

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>