### PR TITLE
users/versioning: Improve external versioning example script for Windows

### DIFF
--- a/users/versioning.rst
+++ b/users/versioning.rst
@@ -145,21 +145,24 @@ behavior as mentioned above. I created the following script and saved it as
 
     @echo off
 
-    :: We need command extensions for mkdir to create intermediate folders in one go
+    rem Enable UTF-8 encoding to deal with multilingual folder and file names
+    chcp 65001
+
+    rem We need command extensions for md to create intermediate folders in one go
     setlocal EnableExtensions
 
-    :: Where I want my versions stored
-    set VERSIONS_PATH=%USERPROFILE%\.trashcan
+    rem Where I want my versions stored
+    set "VERSIONS_PATH=%USERPROFILE%\.trashcan"
 
-    :: The parameters we get from Syncthing, '~' removes quotes if any
-    set FOLDER_PATH=%~1
-    set FILE_PATH=%~2
+    rem The parameters we get from Syncthing, '~' removes quotes if any
+    set "FOLDER_PATH=%~1"
+    set "FILE_PATH=%~2"
 
-    :: First ensure the dir where we need to store the file exists
-    for %%F in ("%VERSIONS_PATH%\%FILE_PATH%") do set OUTPUT_PATH=%%~dpF
-    if not exist "%OUTPUT_PATH%" mkdir "%OUTPUT_PATH%" || exit /B
+    rem First ensure the dir where we need to store the file exists
+    for %%F in ("%VERSIONS_PATH%\%FILE_PATH%") do set "OUTPUT_PATH=%%~dpF"
+    if not exist "%OUTPUT_PATH%" md "%OUTPUT_PATH%" || exit /B
 
-    :: Finally move the file, overwrite existing file if any
+    rem Finally move the file, overwrite existing file if any
     move /Y "%FOLDER_PATH%\%FILE_PATH%" "%VERSIONS_PATH%\%FILE_PATH%"
 
 Finally, I set ``C:\Users\mfrnd\Scripts\onlylatest.bat %FOLDER_PATH% %FILE_PATH%`` as command name in


### PR DESCRIPTION
Enable UTF-8 support, as otherwise the script will fail with non-native
code pages, e.g. when using non-Latin characters in the English version
of Windows, etc. Use quotes with the "set" command or the script will be
unable to deal with funky characters like "&" in file and folder names.
Use "md" instead of "mkdir", because it is shorter. Lastly, use "rem"
instead of "::" for comments, as this is the only way to comment that
is recommended by Microsoft (and "::" is just a hack in itself).

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>