### PR TITLE
users/config: Add a warning to ignoreDelete

### DIFF
--- a/users/config.rst
+++ b/users/config.rst
@@ -332,7 +332,7 @@ order
 
 ignoreDelete
     .. warning::
-        This has irreversible consequences - use at your own risk.
+        Enabling this is highly not recommended - use at your own risk.
 
     When set to true, this device will pretend not to see instructions to
     delete files from other devices.

--- a/users/config.rst
+++ b/users/config.rst
@@ -334,6 +334,9 @@ ignoreDelete
     When set to true, this device will pretend not to see instructions to
     delete files from other devices.
 
+    .. warning::
+        This has irreversible consequences - use at your own risk.
+
 scanProgressIntervalS
     The interval with which scan progress information is sent to the GUI. Zero
     means the default value (two seconds).

--- a/users/config.rst
+++ b/users/config.rst
@@ -331,11 +331,11 @@ order
     the 1 KB becomes known to the pulling device.
 
 ignoreDelete
-    When set to true, this device will pretend not to see instructions to
-    delete files from other devices.
-
     .. warning::
         This has irreversible consequences - use at your own risk.
+
+    When set to true, this device will pretend not to see instructions to
+    delete files from other devices.
 
 scanProgressIntervalS
     The interval with which scan progress information is sent to the GUI. Zero


### PR DESCRIPTION
Add a warning similar to disableFsync clearly stating that this option
should be used at one's own risk.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>