### PR TITLE
users/config: Update to v33, add missing options and ref links (fixes #310, fixes #375, fixes #442)

### DIFF
--- a/advanced/device-allowednetworks.rst
+++ b/advanced/device-allowednetworks.rst
@@ -1,4 +1,4 @@
-.. _allowed-networks:
+.. _advanced-device-allowednetworks:
 
 allowedNetworks
 ===============

--- a/advanced/folder-autonormalize.rst
+++ b/advanced/folder-autonormalize.rst
@@ -1,3 +1,5 @@
+.. _advanced-folder-autonormalize:
+
 autoNormalize
 =============
 

--- a/advanced/folder-caseSensitiveFS.rst
+++ b/advanced/folder-caseSensitiveFS.rst
@@ -1,4 +1,4 @@
-.. _case-sensitive-fs:
+.. _advanced-folder-casesensitivefs:
 
 caseSensitiveFS
 ===============

--- a/advanced/folder-copyrangemethod.rst
+++ b/advanced/folder-copyrangemethod.rst
@@ -1,4 +1,4 @@
-.. _folder-copyRangeMethod:
+.. _advanced-folder-copyrangemethod:
 
 copyRangeMethod
 ===============

--- a/advanced/folder-disablefsync.rst
+++ b/advanced/folder-disablefsync.rst
@@ -1,3 +1,5 @@
+.. _advanced-folder-disablefsync:
+
 disableFsync
 ============
 

--- a/advanced/folder-ignoredelete.rst
+++ b/advanced/folder-ignoredelete.rst
@@ -1,3 +1,5 @@
+.. _advanced-folder-ignoredelete:
+
 ignoreDelete
 ============
 

--- a/advanced/folder-uselargeblocks.rst
+++ b/advanced/folder-uselargeblocks.rst
@@ -1,3 +1,8 @@
+.. _advanced-folder-uselargeblocks:
+
+useLargeBlocks
+==============
+
 .. versionadded:: 1.2.0
 
     As of Syncthing 1.2.0 large blocks always enabled and the configuration
@@ -11,9 +16,6 @@
 .. versionadded:: 0.14.48
 
     Large blocks can be enabled in Syncthing version 0.14.48 and newer.
-
-useLargeBlocks
-==============
 
 ``useLargeBlocks`` is an advanced folder setting that affects the handling
 of blocks for files larger than 256 MiB. When enabled, the file will be

--- a/advanced/option-connectionlimits.rst
+++ b/advanced/option-connectionlimits.rst
@@ -1,3 +1,5 @@
+.. _advanced-option-connectionlimits:
+
 Connection Limits
 =================
 

--- a/advanced/option-databasetuning.rst
+++ b/advanced/option-databasetuning.rst
@@ -1,4 +1,4 @@
-.. _option-databaseTuning:
+.. _advanced-option-databasetuning:
 
 databaseTuning
 ==============

--- a/advanced/option-maxfolderconcurrency.rst
+++ b/advanced/option-maxfolderconcurrency.rst
@@ -1,3 +1,5 @@
+.. _advanced-option-maxfolderconcurrency:
+
 maxFolderConcurrency
 ====================
 

--- a/advanced/option-usebadger.rst
+++ b/advanced/option-usebadger.rst
@@ -1,3 +1,5 @@
+.. _advanced-option-usebadger:
+
 Environment variable USE_BADGER
 ===============================
 
@@ -60,6 +62,6 @@ We're interested in both stability and performance data. As such, please
 have usage reporting and/or (at the very least) :ref:`crashRep` enabled so
 that we might hear of any serious issues.
 
-Currently the :ref:`option-databaseTuning` option has no effect on Badger.
+Currently the :ref:`advanced-option-databasetuning` option has no effect on Badger.
 It's possible that we might implement the tuning options in Badger as well
 after gathering more data on how it behaves.

--- a/users/config.rst
+++ b/users/config.rst
@@ -301,6 +301,44 @@ ignorePerms
     Automatically correct UTF-8 normalization errors found in file names.
 
 filesystemType
+    The type of file system that the folder uses.
+
+    basic (default)
+        To be used if the folder is intended to store real data. Do not
+        change unless you are a developer and want to test things.
+
+    fake
+        A fake file system type to be used for testing, e.g. when you
+        want to create a folder with a :abbr:`TB (Terrabyte)` or more of
+        random files that can be synced somewhere, or an infinitely
+        large folder to sync files into.
+
+        It has pseudorandom properties, i.e. data read from one fakefs
+        can be written into another fakefs, read back, and it will look
+        consistent, without any real data actually being stored.
+
+        To create an empty file system, use
+
+        .. code-block::
+
+            <folder id="default" path="whatever" ...>
+              <filesystemType>fake</filesystemType>
+
+        You can also specify that it should be prefilled with files,
+
+        .. code-block::
+
+            <folder id="default" path="whatever?size=2000000" ...>
+              <filesystemType>fake</filesystemType>
+
+        which will create a file system filled with 2 :abbr:`TB (Terrabyte)`
+        of random data that can be scanned and synced. The prefilled
+        data is based on a deterministic seed, so you can index it,
+        restart Syncthing, and the index will still be correct for all
+        the stored data.
+
+        Check the source of `fakefs.go <https://github.com/syncthing/syncthing/blob/main/lib/fs/fakefs.go>`_
+        for more options and details.
 
 device
     These must have the ``id`` attribute and can have an ``introducedBy`` attribute,


### PR DESCRIPTION
1. Update the config to v33, so that it matches the config.xml used in
   Syncthing v1.13.x. Make sure that all the elements listed on the page
   are exact copies of the config displayed at the top, so that it will
   easier to update them in the future. Also, remove the second instance
   of device example, as it is not really necessary for all the options
   are explained in details below anyhow.

2. Add missing options with short explanations, so that the config page
   is now complete, matching Syncthing v1.13.x.

3. Add direct links to those config options that have their own pages in
   the Docs. This way, it is possible to quickly navigate there from the
   config page. In the process, fix or add references in the advanced
   options' pages using more explicit wording, so that it is less likely
   they will overlap with other refs. Also, rename the advanced options
   RST file when necessary.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>