### PR TITLE
users/config: Increase the scariness of ignoreDelete warning (ref #608)

### DIFF
--- a/advanced/folder-ignoredelete.rst
+++ b/advanced/folder-ignoredelete.rst
@@ -7,8 +7,10 @@ are ignored.
 
 .. warning:: This option should normally be set to ``false``. Changing
   it is not recommended, unless you are a power user and know exactly
-  what you are doing. If you still indend to modify the default value,
-  please read the explanation below very thoroughly before doing so.
+  what you are doing. Once enabled, the database will become permanently
+  corrupted, leading to an irreversible out-of-sync status. If you still
+  indend to modify the default value, please read the explanation below
+  very thoroughly before doing so.
 
 Example Scenario
 ----------------

--- a/users/config.rst
+++ b/users/config.rst
@@ -332,7 +332,8 @@ order
 
 ignoreDelete
     .. warning::
-        Enabling this is highly not recommended - use at your own risk.
+        Enabling this will willingly corrupt the database and lead to a
+        permanent out-of-sync state - use at your own risk.
 
     When set to true, this device will pretend not to see instructions to
     delete files from other devices.


### PR DESCRIPTION
Make the warning even scarier in order to discourage users from even
thinking about enabling it.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>