### PR TITLE
dev/building: Update go version to 1.16

### DIFF
--- a/dev/building.rst
+++ b/dev/building.rst
@@ -29,7 +29,7 @@ Prerequisites
 -------------
 
 -  The latest stable version of Go. Earlier releases may work, but we recommend
-   always using the latest stable version. At the time of writing this is **Go 1.14**.
+   always using the latest stable version. At the time of writing this is **Go 1.16**.
 -  Git
 -  If you want to build Debian packages FPM is required. See FPM's
    `installation information <https://fpm.readthedocs.io/en/latest/installing.html>`__.
@@ -53,7 +53,7 @@ Building (Unix)
 
 .. code-block:: bash
 
-    # This should output "go version go1.14" or higher.
+    # This should output "go version go1.16" or higher.
     $ go version
 
     # Pick a place for your Syncthing source.
@@ -81,7 +81,7 @@ Building (Windows)
 
 .. code-block:: batch
 
-    # This should output "go version go1.14" or higher.
+    # This should output "go version go1.16" or higher.
     > go version
 
     # Pick a place for your Syncthing source.


### PR DESCRIPTION
The current stable version of Go as of 2021-02-17 (UTC) is Go 1.16.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>