### PR TITLE
dev/building: Add Windows and Android prerequisite information

### DIFF
--- a/dev/building.rst
+++ b/dev/building.rst
@@ -33,7 +33,9 @@ Prerequisites
 -  Git
 -  If you want to build Debian packages FPM is required. See FPM's
    `installation information <https://fpm.readthedocs.io/en/latest/installing.html>`__.
-
+-  To build Windows packages, installing `goversioninfo <https://github.com/josephspurrier/goversioninfo>`__
+   is recommended in order to add properties and icon to the executable.
+-  Building Android binaries requires `Android NDK <https://developer.android.com/ndk>`__.
 
 If you're not already a Go developer, the easiest way to get going
 is to download the latest version of Go as instructed in

--- a/dev/building.rst
+++ b/dev/building.rst
@@ -33,8 +33,9 @@ Prerequisites
 -  Git
 -  If you want to build Debian packages FPM is required. See FPM's
    `installation information <https://fpm.readthedocs.io/en/latest/installing.html>`__.
--  To build Windows packages, installing `goversioninfo <https://github.com/josephspurrier/goversioninfo>`__
-   is recommended in order to add properties and icon to the executable.
+-  To build Windows executables, installing `goversioninfo
+   <https://github.com/josephspurrier/goversioninfo>`__ is recommended
+   in order to add file properties and icon to the compiled binaries.
 -  Building Android binaries requires `Android NDK <https://developer.android.com/ndk>`__.
 
 If you're not already a Go developer, the easiest way to get going


### PR DESCRIPTION
Add information about goversioninfo as being recommended when building
Windows binaries, so that the compiled executables have all the file
properties and icon built-in. Also, add information about the need for
the Android NDK if one wants to build Android binaries.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>