### PR TITLE
fix: new /rest/config/insync api path

### DIFF
--- a/rest/config.rst
+++ b/rest/config.rst
@@ -26,7 +26,7 @@ addresses.
 
 .. _rest-config-insync:
 
-/rest/system/config/insync
+/rest/config/insync
 --------------------------
 
 ``GET`` returns whether the config is in sync, i.e. whether the running configuration is


### PR DESCRIPTION
fix new /rest/config/insync api path

https://docs.syncthing.net/rest/system-config-insync-get.html 

should use /rest/config/insync instead