### PR TITLE
advanced/option-usebadger: Deprecate and warn against using Badger

### DIFF
--- a/advanced/option-usebadger.rst
+++ b/advanced/option-usebadger.rst
@@ -7,7 +7,8 @@ Environment variable USE_BADGER
 *Removed in version 1.14.0.*
 
 .. warning:: Badger experiment has been removed and the environment
-   variable is no longer supported.
+   variable is no longer supported. Version 1.14.0 is that last one that
+   allows switching back from Badger to LevelDB.
 
 Syncthing traditionally uses the LevelDB database (`syndtr/goleveldb
 <https://github.com/syndtr/goleveldb>`__). While this has served us well for

--- a/advanced/option-usebadger.rst
+++ b/advanced/option-usebadger.rst
@@ -2,7 +2,10 @@ Environment variable USE_BADGER
 ===============================
 
 .. versionadded:: 1.7.0
-.. deprecated:: 1.14.0
+.. deprecated:: 1.12.0
+
+*Removed in version 1.14.0.*
+
 .. warning:: Badger experiment has been removed and the environment
    variable is no longer supported.
 

--- a/advanced/option-usebadger.rst
+++ b/advanced/option-usebadger.rst
@@ -2,6 +2,9 @@ Environment variable USE_BADGER
 ===============================
 
 .. versionadded:: 1.7.0
+.. deprecated:: 1.14.0
+.. warning:: Badger support has been removed and the environment variable is no
+   longer supported.
 
 Syncthing traditionally uses the LevelDB database (`syndtr/goleveldb
 <https://github.com/syndtr/goleveldb>`__). While this has served us well for

--- a/advanced/option-usebadger.rst
+++ b/advanced/option-usebadger.rst
@@ -4,8 +4,6 @@ Environment variable USE_BADGER
 .. versionadded:: 1.7.0
 .. deprecated:: 1.12.0
 
-*Removed in version 1.14.0.*
-
 .. warning:: Badger experiment has been removed and the environment
    variable is no longer supported. Version 1.14.0 is that last one that
    allows switching back from Badger to LevelDB.

--- a/advanced/option-usebadger.rst
+++ b/advanced/option-usebadger.rst
@@ -3,8 +3,8 @@ Environment variable USE_BADGER
 
 .. versionadded:: 1.7.0
 .. deprecated:: 1.14.0
-.. warning:: Badger support has been removed and the environment variable is no
-   longer supported.
+.. warning:: Badger experiment has been removed and the environment
+   variable is no longer supported.
 
 Syncthing traditionally uses the LevelDB database (`syndtr/goleveldb
 <https://github.com/syndtr/goleveldb>`__). While this has served us well for


### PR DESCRIPTION
Badger support is being removed as of Syncthing 1.14.x. For this reason,
add a note about the environment variable being deprecatd, and also warn
against using it.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>