### PR TITLE
users/versioning: External Versioning command path need not be absolute

### DIFF
--- a/users/versioning.rst
+++ b/users/versioning.rst
@@ -81,8 +81,8 @@ This versioning method delegates the decision on what to do to an
 external command (e.g. a program or a command line script). Just prior
 to a file being replaced, the command will be executed. The file needs
 to be removed from the folder in the process, or otherwise Syncthing
-will report an error. The command should be specified as an absolute
-path, and it can use the following templated arguments:
+will report an error. The command should be specified as a path, and it
+can use the following templated arguments:
 
 ..
     This to be added when actually relevant.

--- a/users/versioning.rst
+++ b/users/versioning.rst
@@ -81,8 +81,8 @@ This versioning method delegates the decision on what to do to an
 external command (e.g. a program or a command line script). Just prior
 to a file being replaced, the command will be executed. The file needs
 to be removed from the folder in the process, or otherwise Syncthing
-will report an error. The command should be specified as a path, and it
-can use the following templated arguments:
+will report an error. The command can use the following templated
+arguments:
 
 ..
     This to be added when actually relevant.


### PR DESCRIPTION
The external versioning path does not necessarily need to be absolute.
For instance, it is possible to a) use a program included in the system
PATH, such as cmd.exe or powershell.exe in Windows, to embed the whole
command, or b) when not specified, the path is relative to the folder,
where the Syncthing binary has been executed.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>