### PR TITLE
users/versioning: Use quotes in batch command name

### DIFF
--- a/users/versioning.rst
+++ b/users/versioning.rst
@@ -176,8 +176,8 @@ behavior as mentioned above. I created the following script and saved it as
     rem Finally move the file, overwrite existing file if any
     move /Y "%FOLDER_PATH%\%FILE_PATH%" "%VERSIONS_PATH%\%FILE_PATH%"
 
-Finally, I set ``C:\Users\mfrnd\Scripts\onlylatest.bat %FOLDER_PATH% %FILE_PATH%``
-as the command name in Syncthing.
+Finally, I set ``"C:\Users\mfrnd\Scripts\onlylatest.bat" "%FOLDER_PATH%"
+"%FILE_PATH%"`` as the command name in Syncthing.
 
 Move to the Recycle Bin using PowerShell
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Quotes are required if the paths include spaces.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>