### PR TITLE
Update reverse proxy setup instructions for caddy v2

### DIFF
--- a/users/reverseproxy.rst
+++ b/users/reverseproxy.rst
@@ -75,8 +75,7 @@ Caddy v2
 
 .. code-block:: none
 
-    handle /syncthing/* {
-        uri strip_prefix /syncthing
+    handle_path /syncthing/* {
         reverse_proxy http://localhost:8384
     }
 

--- a/users/reverseproxy.rst
+++ b/users/reverseproxy.rst
@@ -75,9 +75,10 @@ Caddy v2
 
 .. code-block:: none
 
-    example.com
-
-    reverse_proxy /syncthing 127.0.0.1:8384
+    handle /syncthing/* {
+        uri strip_prefix /syncthing
+        reverse_proxy http://localhost:8384
+    }
 
 
 Folder Configuration


### PR DESCRIPTION
Currently the config in [docs](https://docs.syncthing.net/users/reverseproxy.html#caddy-v2) tells caddy to proxy `/syncthing` to the same path. However, accessing this path returns 404 because syncthing actually listens at `/`.

To proxy to the correct path, the updated config strips the prefix from url.