### PR TITLE
users: Add a rough architecture overview to the man page.

### DIFF
--- a/specs/untrusted.rst
+++ b/specs/untrusted.rst
@@ -1,9 +1,9 @@
-.. _untrusted:
-
 .. warning::
    This feature is currently in public testing and not yet recommended to be
    used for important data. Related UI controls are hidden by a feature flag -
    check the release notes for information on how to test it.
+
+.. _untrusted:
 
 Untrusted Device Encryption
 ===========================

--- a/users/syncthing.rst
+++ b/users/syncthing.rst
@@ -27,6 +27,14 @@ data is your data alone and you deserve to choose where it is stored. Therefore
 Syncthing does not upload your data to the cloud but exchanges your data across
 your machines as soon as they are online at the same time.
 
+The ``syncthing`` core application is a command-line program which usually runs
+in the background and handles the synchronization. It provides a built-in, HTML
+and JavaScript based user interface to be controlled from a web browser. This
+frontend communicates with the core application through some HTTP APIs, which
+other apps like graphical system integration helpers can use as well, for
+greatest flexibility. A link to reach the GUI and API is printed among the first
+few log messages.
+
 Options
 -------
 


### PR DESCRIPTION
Insert one paragraph after the overview description to give a starting point for CLI users reading the man page and trying to discover the GUI.

This could be useful for people installing the DEB package for example, then seeing only an installed daemon binary and a man page.  This will point them to the Web UI in case they missed the Getting Started Guide. As suggested [on the forum](https://forum.syncthing.net/t/great-technology-bad-user-interface/16781/4).