### PR TITLE
link directly to repo

### DIFF
--- a/users/autostart.rst
+++ b/users/autostart.rst
@@ -362,7 +362,7 @@ user has logged into the system (e.g., via the graphical login screen, or ssh).
 Thus, the user service is intended to be used on a *(multiuser) desktop
 computer*. It avoids unnecessarily running Syncthing instances.
 
-The official `Debian/Ubuntu Syncthing repository <https://syncthing.net/downloads/#debian--ubuntu-packages>`__, and
+The official `Debian/Ubuntu Syncthing repository <https://apt.syncthing.net/>`__, and
 several distros (including Arch Linux) ship these service files along with
 the Syncthing package. If your distro provides the systemd service files for
 Syncthing, you can skip step #2 when you're setting up either the system service


### PR DESCRIPTION
The downloads page doesn't contain repository instructions anymore, so a direct link to the repo makes more sense.