### PR TITLE
rest: Add DELETE methods for cluster/pending endpoints.

### DIFF
--- a/events/pendingdeviceschanged.rst
+++ b/events/pendingdeviceschanged.rst
@@ -18,13 +18,13 @@ unknown ID) or removed (device is ignored, dismissed or added).
 	"added": [
 	  {
 	    "address": "127.0.0.1:51807",
-	    "device": "EJHMPAQ-OGCVORE-ISB4IS3-SYYVJXF-TKJGLTU-66DIQPF-GJ5D2GX-GQ3OWQK",
+	    "deviceID": "EJHMPAQ-OGCVORE-ISB4IS3-SYYVJXF-TKJGLTU-66DIQPF-GJ5D2GX-GQ3OWQK",
 	    "name": "My dusty computer"
 	  }
 	],
 	"removed": [
 	  {
-	    "device": "P56IOI7-MZJNU2Y-IQGDREY-DM2MGTI-MGL3BXN-PQ6W5BM-TBBZ4TJ-XZWICQ2"
+	    "deviceID": "P56IOI7-MZJNU2Y-IQGDREY-DM2MGTI-MGL3BXN-PQ6W5BM-TBBZ4TJ-XZWICQ2"
 	  }
 	]
       }

--- a/events/pendingdeviceschanged.rst
+++ b/events/pendingdeviceschanged.rst
@@ -6,7 +6,7 @@ PendingDevicesChanged
 .. versionadded:: 1.14.0
 
 Emitted when pending devices were added / updated (connection from
-unknown ID) or removed (device is ignored or added).
+unknown ID) or removed (device is ignored, dismissed or added).
 
 .. code-block:: json
 

--- a/events/pendingfolderschanged.rst
+++ b/events/pendingfolderschanged.rst
@@ -7,9 +7,9 @@ PendingFoldersChanged
 
 Emitted when pending folders were added / updated (offered by some
 device, but not shared to them) or removed (folder ignored, dismissed
-or added or no longer offered from the remote device).  An entry
-without a ``device`` attribute means that the folder is no longer
-pending for any device.
+or added or no longer offered from the remote device).  A removed
+entry without a ``deviceID`` attribute means that the folder is no
+longer pending for any device.
 
 .. code-block:: json
 
@@ -20,18 +20,18 @@ pending for any device.
       "data": {
 	"added": [
 	  {
-	    "device": "EJHMPAQ-OGCVORE-ISB4IS3-SYYVJXF-TKJGLTU-66DIQPF-GJ5D2GX-GQ3OWQK",
-	    "folder": "GXWxf-3zgnU",
+	    "deviceID": "EJHMPAQ-OGCVORE-ISB4IS3-SYYVJXF-TKJGLTU-66DIQPF-GJ5D2GX-GQ3OWQK",
+	    "folderID": "GXWxf-3zgnU",
 	    "folderLabel": "My Pictures"
 	  }
 	],
 	"removed": [
 	  {
-	    "device": "P56IOI7-MZJNU2Y-IQGDREY-DM2MGTI-MGL3BXN-PQ6W5BM-TBBZ4TJ-XZWICQ2",
-	    "folder": "neyfh-sa2nu"
+	    "deviceID": "P56IOI7-MZJNU2Y-IQGDREY-DM2MGTI-MGL3BXN-PQ6W5BM-TBBZ4TJ-XZWICQ2",
+	    "folderID": "neyfh-sa2nu"
 	  },
 	  {
-	    "folder": "abcde-fghij"
+	    "folderID": "abcde-fghij"
 	  }
 	]
       }

--- a/events/pendingfolderschanged.rst
+++ b/events/pendingfolderschanged.rst
@@ -7,7 +7,9 @@ PendingFoldersChanged
 
 Emitted when pending folders were added / updated (offered by some
 device, but not shared to them) or removed (folder ignored, dismissed
-or added or no longer offered from the remote device).
+or added or no longer offered from the remote device).  An entry
+without a ``device`` attribute means that the folder is no longer
+pending for any device.
 
 .. code-block:: json
 
@@ -27,6 +29,9 @@ or added or no longer offered from the remote device).
 	  {
 	    "device": "P56IOI7-MZJNU2Y-IQGDREY-DM2MGTI-MGL3BXN-PQ6W5BM-TBBZ4TJ-XZWICQ2",
 	    "folder": "neyfh-sa2nu"
+	  },
+	  {
+	    "folder": "abcde-fghij"
 	  }
 	]
       }

--- a/events/pendingfolderschanged.rst
+++ b/events/pendingfolderschanged.rst
@@ -6,8 +6,8 @@ PendingFoldersChanged
 .. versionadded:: 1.14.0
 
 Emitted when pending folders were added / updated (offered by some
-device, but not shared to them) or removed (folder ignored or added or
-no longer offered from the remote device).
+device, but not shared to them) or removed (folder ignored, dismissed
+or added or no longer offered from the remote device).
 
 .. code-block:: json
 

--- a/rest/cluster-pending-devices-delete.rst
+++ b/rest/cluster-pending-devices-delete.rst
@@ -3,10 +3,9 @@ DELETE /rest/cluster/pending/devices
 
 .. versionadded:: 1.18.0
 
-Remove records about a pending remote device, without ignoring it in
-the configuration.  Valid values for the ``device`` parameter are
-those from the corresponding :doc:`/rest/cluster-pending-devices-get`
-endpoint.
+Remove records about a pending remote device which tried to connect.
+Valid values for the ``device`` parameter are those from the
+corresponding :doc:`/rest/cluster-pending-devices-get` endpoint.
 
 .. code-block:: bash
 
@@ -15,3 +14,7 @@ endpoint.
 Returns status 200 and no content upon success, or status 500 and a
 plain text error on failure.  A :doc:`/events/pendingdeviceschanged`
 event will be generated in response.
+
+For a more permanent effect, also for future connections from the same
+device ID, the device should be ignored in the :doc:`configuration
+</users/config>` instead.

--- a/rest/cluster-pending-devices-delete.rst
+++ b/rest/cluster-pending-devices-delete.rst
@@ -1,0 +1,17 @@
+DELETE /rest/cluster/pending/devices
+====================================
+
+.. versionadded:: 1.18.0
+
+Remove records about a pending remote device, without ignoring it in
+the configuration.  Valid values for the ``device`` parameter are
+those from the corresponding :doc:`/rest/cluster-pending-devices-get`
+endpoint.
+
+.. code-block:: bash
+
+    $ curl -X DELETE -H "X-API-Key: abc123" http://localhost:8384/rest/cluster/pending/devices?device=P56IOI7-MZJNU2Y-IQGDREY-DM2MGTI-MGL3BXN-PQ6W5BM-TBBZ4TJ-XZWICQ2
+
+Returns status 200 and no content upon success, or status 500 and a
+plain text error on failure.  A :doc:`/events/pendingdeviceschanged`
+event will be generated in response.

--- a/rest/cluster-pending-folders-delete.rst
+++ b/rest/cluster-pending-folders-delete.rst
@@ -3,12 +3,12 @@ DELETE /rest/cluster/pending/folders
 
 .. versionadded:: 1.18.0
 
-Remove records about a pending folder, without ignoring it in the
-configuration.  Valid values for the ``folder`` and ``device``
-parameters are those from the corresponding
-:doc:`/rest/cluster-pending-folders-get` endpoint.  The ``device``
-parameter is optional and affects announcements of this folder from
-*any* device if omitted.
+Remove records about a pending folder announced from a remote device.
+Valid values for the ``folder`` and ``device`` parameters are those
+from the corresponding :doc:`/rest/cluster-pending-folders-get`
+endpoint.  The ``device`` parameter is optional and affects
+announcements of this folder from the given device, or from *any*
+device if omitted.
 
 .. code-block:: bash
 
@@ -17,3 +17,7 @@ parameter is optional and affects announcements of this folder from
 Returns status 200 and no content upon success, or status 500 and a
 plain text error on failure.  A :doc:`/events/pendingfolderschanged`
 event will be generated in response.
+
+For a more permanent effect, also for future announcements of the same
+folder ID, the folder should be ignored in the :doc:`configuration
+</users/config>` instead.

--- a/rest/cluster-pending-folders-delete.rst
+++ b/rest/cluster-pending-folders-delete.rst
@@ -1,0 +1,19 @@
+DELETE /rest/cluster/pending/folders
+====================================
+
+.. versionadded:: 1.18.0
+
+Remove records about a pending folder, without ignoring it in the
+configuration.  Valid values for the ``folder`` and ``device``
+parameters are those from the corresponding
+:doc:`/rest/cluster-pending-folders-get` endpoint.  The ``device``
+parameter is optional and affects announcements of this folder from
+*any* device if omitted.
+
+.. code-block:: bash
+
+    $ curl -X DELETE -H "X-API-Key: abc123" http://localhost:8384/rest/cluster/pending/folders?folder=cpkn4-57ysy&device=P56IOI7-MZJNU2Y-IQGDREY-DM2MGTI-MGL3BXN-PQ6W5BM-TBBZ4TJ-XZWICQ2
+
+Returns status 200 and no content upon success, or status 500 and a
+plain text error on failure.  A :doc:`/events/pendingfolderschanged`
+event will be generated in response.


### PR DESCRIPTION
Proposed API to fix https://github.com/syncthing/syncthing/issues/7700.

Slighly improves the description of `PendingFoldersChanged` event along the way.