### PR TITLE
events: Document missing event types

### DIFF
--- a/events/failure.rst
+++ b/events/failure.rst
@@ -1,0 +1,17 @@
+Failure
+-------
+
+Generated for specific errors that will also be sent to the usage
+reporting server, if enabled in the configuration.  These are usually
+of special interest to the developers to troubleshoot complex errors.
+The ``data`` field contains a textual error message.
+
+.. code-block:: json
+
+    {
+      "id": 93,
+      "globalID": 93,
+      "type": "Failure",
+      "time": "2021-06-07T21:22:03.414609034+02:00",
+      "data": "index handler got paused while already paused"
+    }

--- a/events/folderpaused.rst
+++ b/events/folderpaused.rst
@@ -1,0 +1,18 @@
+FolderPaused
+------------
+
+Generated when the configuration changes regarding the "paused" state
+of a folder.  Sent repeatedly for each changed folder.
+
+.. code-block:: json
+
+    {
+      "id": 93,
+      "globalID": 93,
+      "type": "FolderPaused",
+      "time": "2021-06-07T23:45:03.414609034+02:00",
+      "data": {
+	"id": "abcde-fghij",
+	"label": "My folder"
+      }
+    }

--- a/events/folderresumed.rst
+++ b/events/folderresumed.rst
@@ -1,0 +1,18 @@
+FolderResumed
+-------------
+
+Generated when the configuration changes regarding the "paused" state
+of a folder.  Sent repeatedly for each changed folder.
+
+.. code-block:: json
+
+    {
+      "id": 93,
+      "globalID": 93,
+      "type": "FolderResumed",
+      "time": "2021-06-07T23:45:03.414609034+02:00",
+      "data": {
+	"id": "abcde-fghij",
+	"label": "My folder"
+      }
+    }

--- a/events/folderscanprogress.rst
+++ b/events/folderscanprogress.rst
@@ -1,5 +1,5 @@
-Folder Scan Progress
---------------------
+FolderScanProgress
+------------------
 
 Emitted in regular intervals (folder setting ProgressIntervalS, 2s by default)
 during scans giving the amount of bytes already scanned and to be scanned in

--- a/events/listenaddresseschanged.rst
+++ b/events/listenaddresseschanged.rst
@@ -1,7 +1,5 @@
-.. listen-addresses-changed:
-
-Listen Addresses Changed
-------------------------
+ListenAddressesChanged
+----------------------
 
 This event is emitted when a :ref:`listen address <listen-addresses>` changes.
 

--- a/events/loginattempt.rst
+++ b/events/loginattempt.rst
@@ -1,5 +1,5 @@
-Login Attempt
--------------
+LoginAttempt
+------------
 
 When authentication is enabled for the GUI, this event is emitted on every
 login attempt. If either the username or password are incorrect, ``success``

--- a/events/remotedownloadprogress.rst
+++ b/events/remotedownloadprogress.rst
@@ -1,5 +1,5 @@
-Remote Download Progress
-------------------------
+RemoteDownloadProgress
+----------------------
 
 This event is emitted when a :ref:`download-progress` message is
 received. It returns a map ``data`` of filenames with a count of


### PR DESCRIPTION
Compared to the code in the main repo, these three were missing:

* Failure
* FolderPaused
* FolderResumed
