### PR TITLE
users/faq-parts: Replace fsync with Möbius sync

### DIFF
--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -67,9 +67,8 @@ iOS
 
 - `Möbius Sync <https://www.mobiussync.com/>`_
 
-  Möbius Sync is an alternative implementation of Syncthing (using the same network
-  protocol) and uses a somewhat outdated fork of Syncthing's code at its core. The
-  iOS application is currently closed source.
+  Möbius Sync is a native iOS application bundle. It hosts and wraps a somewhat outdated fork of Syncthing's code. 
+  The iOS application is currently closed source.
   
 Packages and Bundlings
 ----------------------

--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -62,6 +62,15 @@ Linux
 
   Small bash application with minimal dependencies, for a simple colorful representation of the current status.
 
+iOS
+~~~
+
+- `Möbius Sync <https://www.mobiussync.com/>`_
+
+  Möbius Sync is an alternative implementation of Syncthing (using the same network
+  protocol) and uses a somewhat outdated fork of Syncthing's code at its core. The
+  iOS application is currently closed source.
+  
 Packages and Bundlings
 ----------------------
 

--- a/users/faq-parts/general.rst
+++ b/users/faq-parts/general.rst
@@ -83,7 +83,9 @@ Why is there no iOS client?
 ---------------------------
 
 There is an alternative implementation of Syncthing (using the same network
-protocol) called ``fsync()``. There are no plans by the current Syncthing
+protocol) called `Möbius Sync <https://www.mobiussync.com/>`__, which uses a
+somewhat outdated fork of Syncthing's code at its core. The iOS application
+is currently closed source. There are no plans by the current Syncthing
 team to support iOS in the foreseeable future, as the code required to do so
 would be quite different from what Syncthing is today.
 

--- a/users/faq-parts/general.rst
+++ b/users/faq-parts/general.rst
@@ -79,15 +79,14 @@ Sync uses an undocumented, closed protocol with unknown security properties.
 
 .. [#resiliosync] https://en.wikipedia.org/wiki/Resilio_Sync
 
-Why is there no iOS client?
+Is there an iOS client?
 ---------------------------
 
-There is an alternative implementation of Syncthing (using the same network
-protocol) called `Möbius Sync <https://www.mobiussync.com/>`__, which uses a
-somewhat outdated fork of Syncthing's code at its core. The iOS application
-is currently closed source. There are no plans by the current Syncthing
-team to support iOS in the foreseeable future, as the code required to do so
-would be quite different from what Syncthing is today.
+  `Möbius Sync <https://www.mobiussync.com/>`__ is a native iOS application 
+  bundle that hosts and wraps a somewhat outdated fork of Syncthing's code. 
+  The iOS application is currently closed source. There are no plans by the
+  current Syncthing team to support iOS in the foreseeable future, as the 
+  code required to do so would be quite different from what Syncthing is today.
 
 Should I keep my device IDs secret?
 -----------------------------------


### PR DESCRIPTION
The fsync() app is no longer on Apple's App Store, and hasn't been updated in years.
Möbius Sync is on the App Store, and appears to be actively developed.
For details, see the FAQ item titled "Is Möbius Sync open source?' at 
https://www.mobiussync.com/faq/