### PR TITLE
Clarify temporary file's long file names

### DIFF
--- a/users/syncing.rst
+++ b/users/syncing.rst
@@ -148,6 +148,4 @@ up to a day. This is to avoid needlessly requesting data over the network.
 The temporary files are named ``.syncthing.original-filename.ext.tmp`` or,
 on Windows, ``~syncthing~original-filename.ext.tmp`` where
 ``original-filename.ext`` is the destination filename. The temporary file is
-normally hidden. If the temporary file name would be too long due to the
-addition of the prefix and extra extension, a hash of the original file name
-is used instead of the actual original file name.
+normally hidden. If the temporary file name would be too long due to the addition of the prefix and extra extension, the temporary files are named .syncthing.<hash>.tmp or, on Windows, ~syncthing~<hash>.tmp where <hash> is a SHA-256 hash of the original filename.


### PR DESCRIPTION
Unfortunately I don't understand the width formatting and don't want to choose an arbitrary word wrap count, so I just left the sentence as it is, please let me know if (and how) to change this