### PR TITLE
usage: Add title

### DIFF
--- a/users/syncthing.rst
+++ b/users/syncthing.rst
@@ -1,7 +1,7 @@
 .. _syncthing:
 .. role:: strike
 
-Syncthing
+Syncthing Command Line Operation
 =========
 
 Synopsis


### PR DESCRIPTION
It's the only page where the link to it isn't in the page's title.