### PR TITLE
rest: Dont use default as folder ID example

### DIFF
--- a/rest/system-reset-post.rst
+++ b/rest/system-reset-post.rst
@@ -6,6 +6,6 @@ Syncthing. With no query parameters, the entire database is erased from disk.
 By specifying the ``folder`` parameter with a valid folder ID, only
 information for that folder will be erased::
 
-	$ curl -X POST -H "X-API-Key: abc123" http://localhost:8384/rest/system/reset?folder=default
+	$ curl -X POST -H "X-API-Key: abc123" http://localhost:8384/rest/system/reset?folder=ab1c2-def3g
 
 **Caution**: See ``-reset-database`` for ``.stfolder`` creation side-effect and caution regarding mountpoints.


### PR DESCRIPTION
Folder ID-s usually look more like `ab1c2-def3g`. Changing to `default` to `ab1c2-def3g` makes more sense.

Correct me if I'm wrong.