### PR TITLE
Document missing CLI option flags and use double-dash consistently.

### DIFF
--- a/dev/debugging.rst
+++ b/dev/debugging.rst
@@ -42,7 +42,7 @@ Follow these steps:
 ::
 
     $ go run build.go -debug-binary build
-    $ STNODEFAULTFOLDER=1 STNOUPGRADE=1  STNORESTART=1 dlv --listen=:2345 --headless=true --api-version=2 exec ./syncthing -- -home=./_test_config -no-browser
+    $ STNODEFAULTFOLDER=1 STNOUPGRADE=1  STNORESTART=1 dlv --listen=:2345 --headless=true --api-version=2 exec ./syncthing -- --home=./_test_config --no-browser
 
 For installing and using delve itself see:
 

--- a/includes/env-vars.rst
+++ b/includes/env-vars.rst
@@ -95,10 +95,10 @@ STNODEFAULTFOLDER
     variable will be ignored anytime after the first run.
 
 STNORESTART
-    Equivalent to the ``--no-restart`` flag
+    Equivalent to the ``--no-restart`` flag.
 
 STNOUPGRADE
-    Disable automatic upgrades.
+    Disable automatic upgrades.  Equivalent to the ``--no-upgrade`` flag.
 
 STPROFILER
     Set to a listen address such as "127.0.0.1:9090" to start the profiler with

--- a/includes/env-vars.rst
+++ b/includes/env-vars.rst
@@ -2,7 +2,7 @@ STTRACE
     Used to increase the debugging verbosity in specific or all facilities,
     generally mapping to a Go package. Enabling any of these also enables
     microsecond timestamps, file names plus line numbers. Enter a
-    comma-separated string of facilities to trace. ``syncthing -help`` always
+    comma-separated string of facilities to trace. ``syncthing --help`` always
     outputs an up-to-date list. The valid facility strings are:
 
     Main and operational facilities:
@@ -95,7 +95,7 @@ STNODEFAULTFOLDER
     variable will be ignored anytime after the first run.
 
 STNORESTART
-    Equivalent to the ``-no-restart`` flag
+    Equivalent to the ``--no-restart`` flag
 
 STNOUPGRADE
     Disable automatic upgrades.

--- a/rest/system-reset-post.rst
+++ b/rest/system-reset-post.rst
@@ -8,4 +8,4 @@ information for that folder will be erased::
 
 	$ curl -X POST -H "X-API-Key: abc123" http://localhost:8384/rest/system/reset?folder=ab1c2-def3g
 
-**Caution**: See ``-reset-database`` for ``.stfolder`` creation side-effect and caution regarding mountpoints.
+**Caution**: See ``--reset-database`` for ``.stfolder`` creation side-effect and caution regarding mountpoints.

--- a/users/autostart.rst
+++ b/users/autostart.rst
@@ -90,7 +90,7 @@ https://docs.microsoft.com/windows/win32/taskschd.
    #. Click "New...".
    #. Enter the path to ``syncthing.exe`` in "Program/script:" (for
       example ``C:\syncthing\syncthing.exe``).
-   #. Enter ``-no-console -no-browser`` in "Add arguments (optional):"
+   #. Enter ``--no-console --no-browser`` in "Add arguments (optional):"
    #. Click "OK".
 
    |Windows Task Scheduler Actions Screenshot|
@@ -163,8 +163,8 @@ opening on start, is relatively easy.
    |Windows Startup Folder New Shortcut Screenshot|
 
 #. Enter the path to ``syncthing.exe`` in "Type the location of the item:"
-   followed by ``-no-console -no-browser`` (for example ``C:\syncthing\syncthing.exe
-   -no-console -no-browser``).
+   followed by ``--no-console --no-browser`` (for example ``C:\syncthing\syncthing.exe
+   --no-console --no-browser``).
 
    |Windows Startup Folder Create Shortcut Screenshot|
 
@@ -217,7 +217,7 @@ by a sysadmin who knows enough to understand the security implications.
 #. From an administrator Command Prompt, CD to the NSSM folder and run ``nssm.exe install <syncthing service name>``
 #. Application Tab
 
-   -  Set *Path* to your ``syncthing.exe`` and enter ``-no-restart -no-browser -home="<path to your Syncthing folder>"`` as Arguments. Note: Logging is set later on. ``-logfile`` here will not be applied.
+   -  Set *Path* to your ``syncthing.exe`` and enter ``--no-restart --no-browser --home="<path to your Syncthing folder>"`` as Arguments. Note: Logging is set later on. ``--logfile`` here will not be applied.
    -  |Windows NSSM Configuration Screenshot|
 #. Details Tab
 
@@ -317,7 +317,7 @@ Go to ``/etc/supervisor/conf.d/`` and create a new file named ``syncthing.conf``
     autorestart = True
     directory = /home/<USERNAME>/
     user = <USERNAME>
-    command = /usr/bin/syncthing -no-browser -home="/home/<USERNAME>/.config/syncthing"
+    command = /usr/bin/syncthing --no-browser --home="/home/<USERNAME>/.config/syncthing"
     environment = STNORESTART="1", HOME="/home/<USERNAME>"
 
 Reload Supervisord::

--- a/users/faq-parts/troubleshooting.rst
+++ b/users/faq-parts/troubleshooting.rst
@@ -6,7 +6,7 @@ Where are the Syncthing logs?
 
 Syncthing logs to stdout by default. On Windows Syncthing by default also
 creates ``syncthing.log`` in Syncthing's home directory (run ``syncthing
--paths`` to see where that is). The command line option ``-logfile`` can be
+--paths`` to see where that is). The command line option ``--logfile`` can be
 used to specify a user-defined logfile.
 
 If you're running a process manager like systemd, check there. If you're
@@ -124,7 +124,7 @@ How can I view the history of changes?
 --------------------------------------
 
 The web GUI contains a ``Recent Changes`` button under the device list which
-displays changes since the last (re)start of Syncthing. With the ``-audit``
+displays changes since the last (re)start of Syncthing. With the ``--audit``
 option you can enable a persistent, detailed log of changes and most
 activities, which contains a ``JSON`` formatted  sequence of events in the
 ``~/.config/syncthing/audit-_date_-_time_.log`` file.

--- a/users/faq-parts/usage.rst
+++ b/users/faq-parts/usage.rst
@@ -170,7 +170,7 @@ own.
 By default, Syncthing will look for a directory ``gui`` inside the Syncthing
 home folder. To change the directory to look for themes, you need to set the
 STGUIASSETS environment variable. To get the concrete directory, run
-syncthing with the ``-paths`` parameter. It will print all the relevant paths,
+syncthing with the ``--paths`` parameter. It will print all the relevant paths,
 including the "GUI override directory".
 
 To add e.g. a red theme, you can create the file ``red/assets/css/theme.css``
@@ -194,7 +194,7 @@ Syncthing.net, you can use Syncthing's built-in automatic upgrade functionality.
 - The upgrade button appears in the web GUI when a new version has been
   released. Pressing it will perform an upgrade.
 
-- To force an upgrade from the command line, run ``syncthing -upgrade``.
+- To force an upgrade from the command line, run ``syncthing --upgrade``.
 
 Note that your system should have CA certificates installed which allows a
 secure connection to GitHub (e.g. FreeBSD requires ``sudo pkg install

--- a/users/syncthing.rst
+++ b/users/syncthing.rst
@@ -13,11 +13,11 @@ Synopsis
               [--generate=<dir>] [--gui-address=<address>] [--gui-apikey=<key>]
               [--home=<dir> | --config=<dir> --data=<dir>]
               [--logfile=<filename>] [--logflags=<flags>]
-	      [--log-max-files=<num>] [--log-max-size=<num>]
+              [--log-max-files=<num>] [--log-max-size=<num>]
               [--no-browser] [--no-console] [--no-restart] [--paths] [--paused]
               [--reset-database] [--reset-deltas] [--unpaused] [--allow-newer-config]
-	      [--upgrade] [--no-upgrade] [--upgrade-check] [--upgrade-to=<url>]
-	      [--verbose] [--version]
+              [--upgrade] [--no-upgrade] [--upgrade-check] [--upgrade-to=<url>]
+              [--verbose] [--version]
 
 Description
 -----------

--- a/users/syncthing.rst
+++ b/users/syncthing.rst
@@ -13,9 +13,11 @@ Synopsis
               [--generate=<dir>] [--gui-address=<address>] [--gui-apikey=<key>]
               [--home=<dir> | --config=<dir> --data=<dir>]
               [--logfile=<filename>] [--logflags=<flags>]
+	      [--log-max-files=<num>] [--log-max-size=<num>]
               [--no-browser] [--no-console] [--no-restart] [--paths] [--paused]
-              [--reset-database] [--reset-deltas] [--unpaused] [--upgrade]
-              [--upgrade-check] [--upgrade-to=<url>] [--verbose] [--version]
+              [--reset-database] [--reset-deltas] [--unpaused] [--allow-newer-config]
+	      [--upgrade] [--no-upgrade] [--upgrade-check] [--upgrade-to=<url>]
+	      [--verbose] [--version]
 
 Description
 -----------
@@ -37,6 +39,11 @@ few log messages.
 
 Options
 -------
+
+.. cmdoption:: --allow-newer-config
+
+    Try loading a config file written by a newer program version, instead of
+    failing immediately.
 
 .. cmdoption:: --audit
 
@@ -63,6 +70,10 @@ Options
 
     Override GUI listen address. Set this to an address (``0.0.0.0:8384``)
     or file path (``/var/run/st.sock``, for UNIX sockets).
+
+.. cmdoption:: --gui-apikey=<string>
+
+    Override the API key needed to access the GUI / REST API.
 
 .. cmdoption:: --home=<dir>
 
@@ -101,6 +112,15 @@ Options
     above). The value 0 is used to disable all of the above. The default is to
     show time only (2).
 
+.. cmdoption:: --log-max-files=<num>
+
+    Number of old files to keep (zero to keep only current).  Applies only when
+    log rotation is enabled through ``--log-max-size``.
+
+.. cmdoption:: --log-max-size=<num>
+
+    Maximum size of any log file (zero to disable log rotation).
+
 .. cmdoption:: --no-browser
 
     Do not start a browser.
@@ -113,6 +133,11 @@ Options
 
     Do not restart Syncthing when it exits. The monitor process will still run
     to handle crashes and writing to logfiles (if configured to).
+
+.. cmdoption:: --no-upgrade
+
+    Disable automatic upgrades.  Equivalent to the ``STNOUPGRADE`` environment
+    variable, see below.
 
 .. cmdoption:: --paths
 

--- a/users/syncthing.rst
+++ b/users/syncthing.rst
@@ -9,13 +9,13 @@ Synopsis
 
 ::
 
-    syncthing [-audit] [-auditfile=<file|-|-->] [-browser-only] [device-id]
-              [-generate=<dir>] [-gui-address=<address>] [-gui-apikey=<key>]
-              [-home=<dir> | -config=<dir> -data=<dir>]
-              [-logfile=<filename>] [-logflags=<flags>]
-              [-no-browser] [-no-console] [-no-restart] [-paths] [-paused]
-              [-reset-database] [-reset-deltas] [-unpaused] [-upgrade]
-              [-upgrade-check] [-upgrade-to=<url>] [-verbose] [-version]
+    syncthing [--audit] [--auditfile=<file|-|-->] [--browser-only] [--device-id]
+              [--generate=<dir>] [--gui-address=<address>] [--gui-apikey=<key>]
+              [--home=<dir> | --config=<dir> --data=<dir>]
+              [--logfile=<filename>] [--logflags=<flags>]
+              [--no-browser] [--no-console] [--no-restart] [--paths] [--paused]
+              [--reset-database] [--reset-deltas] [--unpaused] [--upgrade]
+              [--upgrade-check] [--upgrade-to=<url>] [--verbose] [--version]
 
 Description
 -----------
@@ -38,57 +38,57 @@ few log messages.
 Options
 -------
 
-.. cmdoption:: -audit
+.. cmdoption:: --audit
 
     Write events to timestamped file ``audit-YYYYMMDD-HHMMSS.log``.
 
-.. cmdoption:: -auditfile=<file|-|-->
+.. cmdoption:: --auditfile=<file|-|-->
 
     Use specified file or stream (``"-"`` for stdout, ``"--"`` for stderr) for
     audit events, rather than the timestamped default file name.
 
-.. cmdoption:: -browser-only
+.. cmdoption:: --browser-only
 
    Open the web UI in a browser for an already running Syncthing instance.
 
-.. cmdoption:: -device-id
+.. cmdoption:: --device-id
 
    Print device ID to command line.
 
-.. cmdoption:: -generate=<dir>
+.. cmdoption:: --generate=<dir>
 
     Generate key and config in specified dir, then exit.
 
-.. cmdoption:: -gui-address=<address>
+.. cmdoption:: --gui-address=<address>
 
     Override GUI listen address. Set this to an address (``0.0.0.0:8384``)
     or file path (``/var/run/st.sock``, for UNIX sockets).
 
-.. cmdoption:: -home=<dir>
+.. cmdoption:: --home=<dir>
 
     Set common configuration and data directory. The default configuration
     directory is ``$HOME/.config/syncthing`` (Unix-like),
     ``$HOME/Library/Application Support/Syncthing`` (Mac) and
     ``%LOCALAPPDATA%\Syncthing`` (Windows).
 
-.. cmdoption:: -config=<dir>
+.. cmdoption:: --config=<dir>
 
-    Set configuration directory. Alternative to ``-home`` and must be used
-    together with ``-data``.
+    Set configuration directory. Alternative to ``--home`` and must be used
+    together with ``--data``.
 
-.. cmdoption:: -data=<dir>
+.. cmdoption:: --data=<dir>
 
-    Set data (e.g. database) directory. Alternative to ``-home`` and must be used
-    together with ``-config``.
+    Set data (e.g. database) directory. Alternative to ``--home`` and must be used
+    together with ``--config``.
 
-.. cmdoption:: -logfile=<filename>
+.. cmdoption:: --logfile=<filename>
 
     Set destination filename for logging (use ``"-"`` for stdout, which is the
     default option).
 
-.. cmdoption:: -logflags=<flags>
+.. cmdoption:: --logflags=<flags>
 
-    Select information in log line prefix. The ``-logflags`` value is a sum of
+    Select information in log line prefix. The ``--logflags`` value is a sum of
     the following:
 
     -  1: Date
@@ -97,33 +97,33 @@ Options
     -  8: Long filename
     - 16: Short filename
 
-    To prefix each log line with date and time, set ``-logflags=3`` (1 + 2 from
+    To prefix each log line with date and time, set ``--logflags=3`` (1 + 2 from
     above). The value 0 is used to disable all of the above. The default is to
     show time only (2).
 
-.. cmdoption:: -no-browser
+.. cmdoption:: --no-browser
 
     Do not start a browser.
 
-.. cmdoption:: -no-console
+.. cmdoption:: --no-console
 
     Hide the console window. (On Windows only)
 
-.. cmdoption:: -no-restart
+.. cmdoption:: --no-restart
 
     Do not restart Syncthing when it exits. The monitor process will still run
     to handle crashes and writing to logfiles (if configured to).
 
-.. cmdoption:: -paths
+.. cmdoption:: --paths
 
     Print the paths used for configuration, keys, database, GUI overrides,
     default sync folder and the log file.
 
-.. cmdoption:: -paused
+.. cmdoption:: --paused
 
     Start with all devices and folders paused.
 
-.. cmdoption:: -reset-database
+.. cmdoption:: --reset-database
 
     Reset the database, forcing a full rescan and resync. Create `.stfolder`
     folders in each sync folder if they do not already exist. **Caution**:
@@ -131,31 +131,31 @@ Options
     Inconsistent versions may result if the mountpoint is later mounted and
     contains older versions.
 
-.. cmdoption:: -reset-deltas
+.. cmdoption:: --reset-deltas
 
     Reset delta index IDs, forcing a full index exchange.
 
-.. cmdoption:: -unpaused
+.. cmdoption:: --unpaused
 
     Start with all devices and folders unpaused.
 
-.. cmdoption:: -upgrade
+.. cmdoption:: --upgrade
 
     Perform upgrade.
 
-.. cmdoption:: -upgrade-check
+.. cmdoption:: --upgrade-check
 
     Check for available upgrade.
 
-.. cmdoption:: -upgrade-to=<url>
+.. cmdoption:: --upgrade-to=<url>
 
     Force upgrade directly from specified URL.
 
-.. cmdoption:: -verbose
+.. cmdoption:: --verbose
 
     Print verbose log output.
 
-.. cmdoption:: -version
+.. cmdoption:: --version
 
     Show version.
 


### PR DESCRIPTION
The command-line help output lists all options formatted with `--double-dashes`.  Although Syncthing actually accepts both single and double dash forms, I think keeping consistency between CLI help and docs helps avoid confusion.

The same changes could probably be done for `stdiscosrv` and `strelaysrv`, as well as the `build.go` script documentation.  They seem to accept double dashes as well, but print the single dash in their help output.

Newly documented options:
 * `--log-max-files`
 * `--log-max-size`
 * `--allow-newer-config`
 * `--no-upgrade`
 * `--gui-apikey`

One important fix is in the `syncthing` command synopsis, where `[device-id]` was looking like an optional argument to be specified, because of the missing dash(es).