### PR TITLE
users/syncthing: Explain the different CLI modes based on sub-commands.

### DIFF
--- a/includes/cli-commands.rst
+++ b/includes/cli-commands.rst
@@ -1,7 +1,7 @@
-The available sub-commands are grouped into several nested hierarchies and
-dynamically generated from the running Syncthing instance.  On every level, the
-``--help`` option lists the available properties, actions and commands for the
-user to discover interactively.  The top-level groups are:
+The available subcommands are grouped into several nested hierarchies and some
+parts dynamically generated from the running Syncthing instance.  On every
+level, the ``--help`` option lists the available properties, actions and
+commands for the user to discover interactively.  The top-level groups are:
 
 config
     Access the live configuration in a running instance over the REST API to
@@ -27,6 +27,6 @@ debug
     therefore only work when Syncthing is not running.
 
 ``-`` (a single dash)
-    Switches to an interactive mode where commands can be entered sequentially
-    without calling the ``syncthing cli`` command over and over.  Exits on any
-    invalid command or when EOF (end-of-file) is received.
+    Reads subsequent commands from the standard input stream, without needing to
+    call the ``syncthing cli`` command over and over.  Exits on any invalid
+    command or when EOF (end-of-file) is received.

--- a/includes/cli-commands.rst
+++ b/includes/cli-commands.rst
@@ -1,0 +1,32 @@
+The available sub-commands are grouped into several nested hierarchies and
+dynamically generated from the running Syncthing instance.  On every level, the
+``--help`` option lists the available properties, actions and commands for the
+user to discover interactively.  The top-level groups are:
+
+config
+    Access the live configuration in a running instance over the REST API to
+    retrieve (get) or update (set) values in a fine-grained way.  The hierarchy
+    is based on the same structure as used in the JSON / XML representations.
+
+show
+    Show system properties and status of a running instance.  The output is
+    passed on directly from the REST API response and therefore requires parsing
+    JSON format.
+
+operations
+    Control the overall program operation such as restarting or handling
+    upgrades, as well as triggering some actions on a per-folder basis.
+
+errors
+    Examine pending error conditions that need attention from the user, or
+    acknowledge (clear) them.
+
+debug
+    Various tools to aid in diagnosing problems or collection information for
+    bug reports.  Some of these commands access the database directly and can
+    therefore only work when Syncthing is not running.
+
+``-`` (a single dash)
+    Switches to an interactive mode where commands can be entered sequentially
+    without calling the ``syncthing cli`` command over and over.  Exits on any
+    invalid command or when EOF (end-of-file) is received.

--- a/includes/env-vars.rst
+++ b/includes/env-vars.rst
@@ -92,7 +92,8 @@ STHEAPPROFILE
 
 STNODEFAULTFOLDER
     Don't create a default folder when starting for the first time. This
-    variable will be ignored anytime after the first run.
+    variable will be ignored anytime after the first run.  Equivalent to the
+    ``--no-default-folder`` flag.
 
 STNORESTART
     Equivalent to the ``--no-restart`` flag.

--- a/users/syncthing.rst
+++ b/users/syncthing.rst
@@ -9,7 +9,8 @@ Synopsis
 
 ::
 
-    syncthing [--audit] [--auditfile=<file|-|-->] [--browser-only] [--device-id]
+    syncthing [serve]
+              [--audit] [--auditfile=<file|-|-->] [--browser-only] [--device-id]
               [--generate=<dir>] [--gui-address=<address>] [--gui-apikey=<key>]
               [--home=<dir> | --config=<dir> --data=<dir>]
               [--logfile=<filename>] [--logflags=<flags>]
@@ -17,7 +18,7 @@ Synopsis
               [--no-browser] [--no-console] [--no-restart] [--paths] [--paused]
               [--reset-database] [--reset-deltas] [--unpaused] [--allow-newer-config]
               [--upgrade] [--no-upgrade] [--upgrade-check] [--upgrade-to=<url>]
-              [--verbose] [--version]
+              [--verbose] [--version] [--help] [--debug-*]
 
 Description
 -----------
@@ -74,6 +75,11 @@ Options
 .. cmdoption:: --gui-apikey=<string>
 
     Override the API key needed to access the GUI / REST API.
+
+.. cmdoption:: --help -h
+
+    Show help text about command line usage.  Context-sensitive depending on the
+    given sub-command.
 
 .. cmdoption:: --home=<dir>
 

--- a/users/syncthing.rst
+++ b/users/syncthing.rst
@@ -88,10 +88,10 @@ Options
 
     Override the API key needed to access the GUI / REST API.
 
-.. cmdoption:: --help -h
+.. cmdoption:: --help, -h
 
     Show help text about command line usage.  Context-sensitive depending on the
-    given sub-command.
+    given subcommand.
 
 .. cmdoption:: --home=<dir>
 
@@ -251,20 +251,20 @@ Exit codes over 125 are usually returned by the shell/binary loader/default
 signal handler. Exit codes over 128+N on Unix usually represent the signal which
 caused the process to exit. For example, ``128 + 9 (SIGKILL) = 137``.
 
-Sub-Commands
-------------
+Subcommands
+-----------
 
 The command line syntax actually supports different modes of operation through
-several sub-commands, specified as the first argument.  The default one is
-``serve`` and can therefore be omitted.
+several subcommands, specified as the first argument.  If omitted, the default
+``serve`` is assumed.
 
-The ``decrypt`` sub-command is used in conjunction with untrusted (encrypted)
+The ``decrypt`` subcommand is used in conjunction with untrusted (encrypted)
 devices, see the relevant section on :ref:`decryption <untrusted-decrypt>` for
 details.  It does not depend on Syncthing to be running, but works on offline
 data.
 
 To work with the REST API for debugging or automating things in Syncthing, the
-``cli`` sub-command provides easy access to individual features.  It basically
+``cli`` subcommand provides easy access to individual features.  It basically
 saves the hassle of handling HTTP connections and API authentication.
 
 .. include:: ../includes/cli-commands.rst

--- a/users/syncthing.rst
+++ b/users/syncthing.rst
@@ -16,6 +16,7 @@ Synopsis
               [--logfile=<filename>] [--logflags=<flags>]
               [--log-max-files=<num>] [--log-max-size=<num>]
               [--no-browser] [--no-console] [--no-restart] [--paths] [--paused]
+              [--no-default-folder]
               [--reset-database] [--reset-deltas] [--unpaused] [--allow-newer-config]
               [--upgrade] [--no-upgrade] [--upgrade-check] [--upgrade-to=<url>]
               [--verbose] [--version] [--help] [--debug-*]
@@ -145,6 +146,11 @@ Options
 .. cmdoption:: --no-console
 
     Hide the console window. (On Windows only)
+
+.. cmdoption:: --no-default-folder
+
+    Don't create a default folder when generating an initial configuration /
+    starting for the first time.
 
 .. cmdoption:: --no-restart
 

--- a/users/syncthing.rst
+++ b/users/syncthing.rst
@@ -20,6 +20,17 @@ Synopsis
               [--upgrade] [--no-upgrade] [--upgrade-check] [--upgrade-to=<url>]
               [--verbose] [--version] [--help] [--debug-*]
 
+    syncthing decrypt (--to=<dir> | --verify-only)
+              [--password=<pw>] [--folder-id=<id>] [--token-path=<file>]
+              [--continue] [--verbose] [--version] [--help]
+              <path>
+
+    syncthing cli
+              [--home=<dir> | --config=<dir> --data=<dir>]
+              [--gui-address=<address>] [--gui-apikey=<key>]
+              [--help]
+              <command> [command options...] [arguments...]
+
 Description
 -----------
 
@@ -207,6 +218,24 @@ Exit Codes
 Exit codes over 125 are usually returned by the shell/binary loader/default
 signal handler. Exit codes over 128+N on Unix usually represent the signal which
 caused the process to exit. For example, ``128 + 9 (SIGKILL) = 137``.
+
+Sub-Commands
+------------
+
+The command line syntax actually supports different modes of operation through
+several sub-commands, specified as the first argument.  The default one is
+``serve`` and can therefore be omitted.
+
+The ``decrypt`` sub-command is used in conjunction with untrusted (encrypted)
+devices, see the relevant section on :ref:`decryption <untrusted-decrypt>` for
+details.  It does not depend on Syncthing to be running, but works on offline
+data.
+
+To work with the REST API for debugging or automating things in Syncthing, the
+``cli`` sub-command provides easy access to individual features.  It basically
+saves the hassle of handling HTTP connections and API authentication.
+
+.. include:: ../includes/cli-commands.rst
 
 Proxies
 -------

--- a/users/syncthing.rst
+++ b/users/syncthing.rst
@@ -201,6 +201,32 @@ Options
 
     Show version.
 
+.. cmdoption:: --to=<dir>
+
+    Destination directory where files should be stored after decryption.
+
+.. cmdoption:: --verify-only
+
+    Don't write decrypted files to disk (but verify plaintext hashes).
+
+.. cmdoption:: --password=<pw>
+
+    Folder password for decryption / verification.  Can be passed through the
+    ``FOLDER_PASSWORD`` environment variable instead to avoid recording in a
+    shell's history buffer or sniffing from the running processes list.
+
+.. cmdoption:: --folder-id=<id>
+
+    Folder ID of the encrypted folder, if it cannot be determined automatically.
+
+.. cmdoption:: --token-path=<file>
+
+    Path to the token file within the folder (used to determine folder ID).
+
+.. cmdoption:: --continue
+
+    Continue processing next file in case of error, instead of aborting.
+
 Exit Codes
 ----------
 

--- a/users/untrusted.rst
+++ b/users/untrusted.rst
@@ -143,6 +143,8 @@ and receive the data for the new file over the network. However if you have a bi
 e.g. ``video.mp4``, and you modify just a part of it (e.g. video metadata), only
 the changed block is transferred as usual.
 
+.. _untrusted-decrypt:
+
 Decrypting data
 ---------------
 


### PR DESCRIPTION
Add a section about the general concept and include "decrypt" and "cli" in the syncthing command synopsis.  Top-level entry points into the "cli" hierarchy are documented in a separate included snippet.

Hopefully something like that can be auto-generated in the distant future to make sure an up-to-date listing is included in the documentation.

Add options used exclusively in the `decrpyt` mode to the overall options list.