### PR TITLE
usage.rst: Improve wording

### DIFF
--- a/users/faq-parts/usage.rst
+++ b/users/faq-parts/usage.rst
@@ -45,7 +45,7 @@ The easy way to rename or move a synced folder on the local system is to
 remove the folder in the Syncthing UI, move it on disk, then re-add it using
 the new path.
 
-It's best to do this when the folder is already in sync between your
+It's important to do this when the folder is already in sync between your
 devices, as it is otherwise unpredictable which changes will "win" after the
 move. Changes made on other devices may be overwritten, or changes made
 locally may be overwritten by those on other devices.


### PR DESCRIPTION
Please review carefully.

I'm new to syncthing, so I'm not sure I understand it correctly. But the paragraph containing my edit sounds like the proposed actions can actually lead to data loss, which is a serious thing and violates the number one of syncthing's core principles as stated in https://github.com/syncthing/syncthing/blob/main/README.md.

If this is actually the case, I think it should be even rephrased to something like `WARNING: It's very important to do this ...`, and maybe this should be put/reflected also in the paragraph before, since users *might* just go ahead after reading the previous paragraph and just do the rename, reading the warning only after they lost some data.

Also, since one sometimes cannot know when remote devices (or even the local device) changes shared data, this seems like an inherently unsafe procedure, and I'm not sure if that should be kept here in the official usage guide. The alternative way described in the next paragraph sounds much safer (i.e. completely safe).

I'm interested in some discussion about this. Thanks.