### PR TITLE
rest: Remove bogus fields from connections API endpoint.

### DIFF
--- a/rest/system-connections-get.rst
+++ b/rest/system-connections-get.rst
@@ -17,6 +17,7 @@ The connection types are ``TCP (Client)``, ``TCP (Server)``, ``Relay (Client)`` 
 		  "at" : "2015-11-07T17:29:47.691637262+01:00",
 		  "inBytesTotal" : 1479,
 		  "outBytesTotal" : 1318,
+                  "startedAt": "0001-01-01T00:00:00Z"
 	   },
 	   "connections" : {
 		  "YZJBJFX-RDBL7WY-6ZGKJ2D-4MJB4E7-ZATSDUY-LD6Y3L3-MLFUYWE-AEMXJAC" : {

--- a/rest/system-connections-get.rst
+++ b/rest/system-connections-get.rst
@@ -17,7 +17,6 @@ The connection types are ``TCP (Client)``, ``TCP (Server)``, ``Relay (Client)`` 
 		  "at" : "2015-11-07T17:29:47.691637262+01:00",
 		  "inBytesTotal" : 1479,
 		  "outBytesTotal" : 1318,
-                  "startedAt": "0001-01-01T00:00:00Z"
 	   },
 	   "connections" : {
 		  "YZJBJFX-RDBL7WY-6ZGKJ2D-4MJB4E7-ZATSDUY-LD6Y3L3-MLFUYWE-AEMXJAC" : {

--- a/rest/system-connections-get.rst
+++ b/rest/system-connections-get.rst
@@ -24,6 +24,7 @@ The connection types are ``TCP (Client)``, ``TCP (Server)``, ``Relay (Client)`` 
 		     "inBytesTotal" : 556,
 		     "paused" : false,
 		     "at" : "2015-11-07T17:29:47.691548971+01:00",
+		     "startedAt" : "2015-11-07T00:09:47Z",
 		     "clientVersion" : "v0.12.1",
 		     "address" : "127.0.0.1:22002",
 		     "type" : "TCP (Client)",
@@ -34,6 +35,7 @@ The connection types are ``TCP (Client)``, ``TCP (Server)``, ``Relay (Client)`` 
 		     "type" : "",
 		     "address" : "",
 		     "at" : "0001-01-01T00:00:00Z",
+		     "startedAt" : "0001-01-01T00:00:00Z",
 		     "clientVersion" : "",
 		     "paused" : false,
 		     "inBytesTotal" : 0,
@@ -47,6 +49,7 @@ The connection types are ``TCP (Client)``, ``TCP (Server)``, ``Relay (Client)`` 
 		     "inBytesTotal" : 0,
 		     "paused" : false,
 		     "at" : "0001-01-01T00:00:00Z",
+		     "startedAt" : "0001-01-01T00:00:00Z",
 		     "clientVersion" : ""
 		  }
 	   }

--- a/rest/system-connections-get.rst
+++ b/rest/system-connections-get.rst
@@ -2,7 +2,7 @@ GET /rest/system/connections
 ============================
 
 
-.. note:: Return format changed in 0.13.0.
+.. note:: Return format changed in versions 0.13.0 and 1.19.0.
 
 
 Returns the list of configured devices and some metadata associated
@@ -14,14 +14,9 @@ The connection types are ``TCP (Client)``, ``TCP (Server)``, ``Relay (Client)`` 
 
 	{
 	   "total" : {
-		  "paused" : false,
-		  "clientVersion" : "",
 		  "at" : "2015-11-07T17:29:47.691637262+01:00",
-		  "connected" : false,
 		  "inBytesTotal" : 1479,
-		  "type" : "",
 		  "outBytesTotal" : 1318,
-		  "address" : ""
 	   },
 	   "connections" : {
 		  "YZJBJFX-RDBL7WY-6ZGKJ2D-4MJB4E7-ZATSDUY-LD6Y3L3-MLFUYWE-AEMXJAC" : {


### PR DESCRIPTION
Remove fields from the /rest/system/connections element "total" which
are not populated and misleading.  Removed in upcoming version.