### PR TITLE
rest, users: Update configuration to version 35.

### DIFF
--- a/rest/system-config-get.rst
+++ b/rest/system-config-get.rst
@@ -10,22 +10,23 @@ Returns the current configuration.
 .. code-block:: json
 
     {
-      "version": 30,
+      "version": 35,
       "folders": [
 	{
-	  "id": "GXWxf-3zgnU",
-	  "label": "MyFolder",
+	  "id": "default",
+	  "label": "Default Folder",
 	  "filesystemType": "basic",
 	  "path": "...",
 	  "type": "sendreceive",
 	  "devices": [
 	    {
 	      "deviceID": "...",
-	      "introducedBy": ""
+	      "introducedBy": "",
+	      "encryptionPassword": ""
 	    }
 	  ],
-	  "rescanIntervalS": 60,
-	  "fsWatcherEnabled": false,
+	  "rescanIntervalS": 3600,
+	  "fsWatcherEnabled": true,
 	  "fsWatcherDelayS": 10,
 	  "ignorePerms": false,
 	  "autoNormalize": true,
@@ -34,10 +35,11 @@ Returns the current configuration.
 	    "unit": "%"
 	  },
 	  "versioning": {
-	    "type": "simple",
-	    "params": {
-	      "keep": "5"
-	    }
+	    "type": "",
+	    "params": {},
+	    "cleanupIntervalS": 3600,
+	    "fsPath": "",
+	    "fsType": "basic"
 	  },
 	  "copiers": 0,
 	  "pullerMaxPendingKiB": 0,
@@ -46,14 +48,20 @@ Returns the current configuration.
 	  "ignoreDelete": false,
 	  "scanProgressIntervalS": 0,
 	  "pullerPauseS": 0,
-	  "maxConflicts": 10,
+	  "maxConflicts": -1,
 	  "disableSparseFiles": false,
 	  "disableTempIndexes": false,
 	  "paused": false,
 	  "weakHashThresholdPct": 25,
 	  "markerName": ".stfolder",
 	  "copyOwnershipFromParent": false,
-	  "modTimeWindowS": 0
+	  "modTimeWindowS": 0,
+	  "maxConcurrentWrites": 2,
+	  "disableFsync": false,
+	  "blockPullOrder": "standard",
+	  "copyRangeMethod": "standard",
+	  "caseSensitiveFS": false,
+	  "junctionsAsDirs": true
 	}
       ],
       "devices": [
@@ -74,18 +82,27 @@ Returns the current configuration.
 	  "autoAcceptFolders": false,
 	  "maxSendKbps": 0,
 	  "maxRecvKbps": 0,
-	  "ignoredFolders": [],
-	  "maxRequestKiB": 0
+	  "ignoredFolders": [
+	    {
+	      "time": "2022-01-09T19:09:52Z",
+	      "id": "br63e-wyhb7",
+	      "label": "Foo"
+	    }
+	  ],
+	  "maxRequestKiB": 0,
+	  "untrusted": false,
+	  "remoteGUIPort": 0
 	}
       ],
       "gui": {
 	"enabled": true,
 	"address": "127.0.0.1:8384",
+	"unixSocketPermissions": "",
 	"user": "Username",
 	"password": "$2a$10$ZFws69T4FlvWwsqeIwL.TOo5zOYqsa/.TxlUnsGYS.j3JvjFTmxo6",
 	"authMode": "static",
 	"useTLS": false,
-	"apiKey": "pGahcht56664QU5eoFQW6szbEG6Ec2Cr",
+	"apiKey": "k1dnz1Dd0rzTBjjFFh7CXPnrF12C49B1",
 	"insecureAdminAccess": false,
 	"theme": "default",
 	"debugging": false,
@@ -96,7 +113,9 @@ Returns the current configuration.
 	"address": "",
 	"bindDN": "",
 	"transport": "plain",
-	"insecureSkipVerify": false
+	"insecureSkipVerify": false,
+	"searchBaseDN": "",
+	"searchFilter": ""
       },
       "options": {
 	"listenAddresses": [
@@ -114,14 +133,14 @@ Returns the current configuration.
 	"reconnectionIntervalS": 60,
 	"relaysEnabled": true,
 	"relayReconnectIntervalM": 10,
-	"startBrowser": false,
+	"startBrowser": true,
 	"natEnabled": true,
 	"natLeaseMinutes": 60,
 	"natRenewalMinutes": 30,
 	"natTimeoutSeconds": 10,
-	"urAccepted": -1,
-	"urSeen": 2,
-	"urUniqueId": "",
+	"urAccepted": 3,
+	"urSeen": 0,
+	"urUniqueId": "...",
 	"urURL": "https://data.syncthing.net/newdata",
 	"urPostInsecurely": false,
 	"urInitialDelayS": 1800,
@@ -140,9 +159,10 @@ Returns the current configuration.
 	"alwaysLocalNets": [],
 	"overwriteRemoteDeviceNamesOnConnect": false,
 	"tempIndexMinBlocks": 10,
-	"unackedNotificationIDs": [],
+	"unackedNotificationIDs": [
+	  "authenticationUserAndPassword"
+	],
 	"trafficClass": 0,
-	"defaultFolderPath": "~",
 	"setLowPriority": true,
 	"maxFolderConcurrency": 0,
 	"crURL": "https://crash.syncthing.net/newcrash",
@@ -153,7 +173,94 @@ Returns the current configuration.
 	  "default"
 	],
 	"databaseTuning": "auto",
-	"maxConcurrentIncomingRequestKiB": 0
+	"maxConcurrentIncomingRequestKiB": 0,
+	"announceLANAddresses": true,
+	"sendFullIndexOnUpgrade": false,
+	"featureFlags": [],
+	"connectionLimitEnough": 0,
+	"connectionLimitMax": 0,
+	"insecureAllowOldTLSVersions": false
       },
-      "remoteIgnoredDevices": []
+      "remoteIgnoredDevices": [
+	{
+	  "time": "2022-01-09T20:02:01Z",
+	  "deviceID": "...",
+	  "name": "bugger",
+	  "address": "192.168.0.20:22000"
+	}
+      ],
+      "defaults": {
+	"folder": {
+	  "id": "",
+	  "label": "",
+	  "filesystemType": "basic",
+	  "path": "~",
+	  "type": "sendreceive",
+	  "devices": [
+	    {
+	      "deviceID": "...",
+	      "introducedBy": "",
+	      "encryptionPassword": ""
+	    }
+	  ],
+	  "rescanIntervalS": 3600,
+	  "fsWatcherEnabled": true,
+	  "fsWatcherDelayS": 10,
+	  "ignorePerms": false,
+	  "autoNormalize": true,
+	  "minDiskFree": {
+	    "value": 1,
+	    "unit": "%"
+	  },
+	  "versioning": {
+	    "type": "",
+	    "params": {},
+	    "cleanupIntervalS": 3600,
+	    "fsPath": "",
+	    "fsType": "basic"
+	  },
+	  "copiers": 0,
+	  "pullerMaxPendingKiB": 0,
+	  "hashers": 0,
+	  "order": "random",
+	  "ignoreDelete": false,
+	  "scanProgressIntervalS": 0,
+	  "pullerPauseS": 0,
+	  "maxConflicts": 10,
+	  "disableSparseFiles": false,
+	  "disableTempIndexes": false,
+	  "paused": false,
+	  "weakHashThresholdPct": 25,
+	  "markerName": ".stfolder",
+	  "copyOwnershipFromParent": false,
+	  "modTimeWindowS": 0,
+	  "maxConcurrentWrites": 2,
+	  "disableFsync": false,
+	  "blockPullOrder": "standard",
+	  "copyRangeMethod": "standard",
+	  "caseSensitiveFS": false,
+	  "junctionsAsDirs": false
+	},
+	"device": {
+	  "deviceID": "",
+	  "name": "",
+	  "addresses": [
+	    "dynamic"
+	  ],
+	  "compression": "metadata",
+	  "certName": "",
+	  "introducer": false,
+	  "skipIntroductionRemovals": false,
+	  "introducedBy": "",
+	  "paused": false,
+	  "allowedNetworks": [],
+	  "autoAcceptFolders": false,
+	  "maxSendKbps": 0,
+	  "maxRecvKbps": 0,
+	  "ignoredFolders": [],
+	  "maxRequestKiB": 0,
+	  "untrusted": false,
+	  "remoteGUIPort": 0
+	}
+      }
     }

--- a/rest/system-config-get.rst
+++ b/rest/system-config-get.rst
@@ -138,7 +138,7 @@ Returns the current configuration.
 	"natLeaseMinutes": 60,
 	"natRenewalMinutes": 30,
 	"natTimeoutSeconds": 10,
-	"urAccepted": 3,
+	"urAccepted": 0,
 	"urSeen": 0,
 	"urUniqueId": "...",
 	"urURL": "https://data.syncthing.net/newdata",
@@ -185,7 +185,7 @@ Returns the current configuration.
 	{
 	  "time": "2022-01-09T20:02:01Z",
 	  "deviceID": "...",
-	  "name": "bugger",
+	  "name": "...",
 	  "address": "192.168.0.20:22000"
 	}
       ],

--- a/users/config.rst
+++ b/users/config.rst
@@ -1046,9 +1046,9 @@ folder
     fields here will be used for a newly added shared folder.  The ``id``
     attribute is meaningless in this context.
 
-    The UI will propose to create new folders at the path given by the ``path``
+    The UI will propose to create new folders at the path given in the ``path``
     attribute (used to be ``defaultFolderPath`` under ``options``).  It also
-    applies for automatically accepted folders from a remote device.
+    applies to folders automatically accepted from a remote device.
 
     Even sharing with other remote devices can be done in the template by
     including the appropriate ``device`` element underneath.

--- a/users/config.rst
+++ b/users/config.rst
@@ -75,12 +75,18 @@ The following shows an example of a default configuration file (IDs will differ)
 
 .. code-block:: xml
 
-    <configuration version="30">
+    <configuration version="35">
         <folder id="default" label="Default Folder" path="/Users/jb/Sync/" type="sendreceive" rescanIntervalS="3600" fsWatcherEnabled="true" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
             <filesystemType>basic</filesystemType>
-            <device id="3LT2GA5-CQI4XJM-WTZ264P-MLOGMHL-MCRLDNT-MZV4RD3-KA745CL-OGAERQZ"></device>
+            <device id="S7UKX27-GI7ZTXS-GC6RKUA-7AJGZ44-C6NAYEB-HSKTJQK-KJHU2NO-CWV7EQW" introducedBy="">
+                <encryptionPassword></encryptionPassword>
+            </device>
             <minDiskFree unit="%">1</minDiskFree>
-            <versioning></versioning>
+            <versioning>
+                <cleanupIntervalS>3600</cleanupIntervalS>
+                <fsPath></fsPath>
+                <fsType>basic</fsType>
+            </versioning>
             <copiers>0</copiers>
             <pullerMaxPendingKiB>0</pullerMaxPendingKiB>
             <hashers>0</hashers>
@@ -100,14 +106,18 @@ The following shows an example of a default configuration file (IDs will differ)
             <disableFsync>false</disableFsync>
             <blockPullOrder>standard</blockPullOrder>
             <copyRangeMethod>standard</copyRangeMethod>
+            <caseSensitiveFS>false</caseSensitiveFS>
+            <junctionsAsDirs>true</junctionsAsDirs>
         </folder>
-        <device id="3LT2GA5-CQI4XJM-WTZ264P-MLOGMHL-MCRLDNT-MZV4RD3-KA745CL-OGAERQZ" name="syno" compression="metadata" introducer="false" skipIntroductionRemovals="false" introducedBy="">
+        <device id="S7UKX27-GI7ZTXS-GC6RKUA-7AJGZ44-C6NAYEB-HSKTJQK-KJHU2NO-CWV7EQW" name="syno" compression="metadata" introducer="false" skipIntroductionRemovals="false" introducedBy="">
             <address>dynamic</address>
             <paused>false</paused>
             <autoAcceptFolders>false</autoAcceptFolders>
             <maxSendKbps>0</maxSendKbps>
             <maxRecvKbps>0</maxRecvKbps>
+            <ignoredFolder time="2022-01-09T19:09:52Z" id="br63e-wyhb7" label="Foo"></ignoredFolder>
             <maxRequestKiB>0</maxRequestKiB>
+            <untrusted>false</untrusted>
             <remoteGUIPort>0</remoteGUIPort>
         </device>
         <gui enabled="true" tls="false" debugging="false">
@@ -150,8 +160,8 @@ The following shows an example of a default configuration file (IDs will differ)
             <releasesURL>https://upgrades.syncthing.net/meta.json</releasesURL>
             <overwriteRemoteDeviceNamesOnConnect>false</overwriteRemoteDeviceNamesOnConnect>
             <tempIndexMinBlocks>10</tempIndexMinBlocks>
+            <unackedNotificationID>authenticationUserAndPassword</unackedNotificationID>
             <trafficClass>0</trafficClass>
-            <defaultFolderPath>~</defaultFolderPath>
             <setLowPriority>true</setLowPriority>
             <maxFolderConcurrency>0</maxFolderConcurrency>
             <crashReportingURL>https://crash.syncthing.net/newcrash</crashReportingURL>
@@ -161,7 +171,58 @@ The following shows an example of a default configuration file (IDs will differ)
             <stunServer>default</stunServer>
             <databaseTuning>auto</databaseTuning>
             <maxConcurrentIncomingRequestKiB>0</maxConcurrentIncomingRequestKiB>
+            <announceLANAddresses>true</announceLANAddresses>
+            <sendFullIndexOnUpgrade>false</sendFullIndexOnUpgrade>
+            <connectionLimitEnough>0</connectionLimitEnough>
+            <connectionLimitMax>0</connectionLimitMax>
+            <insecureAllowOldTLSVersions>false</insecureAllowOldTLSVersions>
         </options>
+        <remoteIgnoredDevice time="2022-01-09T20:02:01Z" id="5SYI2FS-LW6YAXI-JJDYETS-NDBBPIO-256MWBO-XDPXWVG-24QPUM4-PDW4UQU" name="bugger" address="192.168.0.20:22000"></remoteIgnoredDevice>
+        <defaults>
+            <folder id="" label="" path="~" type="sendreceive" rescanIntervalS="3600" fsWatcherEnabled="true" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
+                <filesystemType>basic</filesystemType>
+                <device id="S7UKX27-GI7ZTXS-GC6RKUA-7AJGZ44-C6NAYEB-HSKTJQK-KJHU2NO-CWV7EQW" introducedBy="">
+                    <encryptionPassword></encryptionPassword>
+                </device>
+                <minDiskFree unit="%">1</minDiskFree>
+                <versioning>
+                    <cleanupIntervalS>3600</cleanupIntervalS>
+                    <fsPath></fsPath>
+                    <fsType>basic</fsType>
+                </versioning>
+                <copiers>0</copiers>
+                <pullerMaxPendingKiB>0</pullerMaxPendingKiB>
+                <hashers>0</hashers>
+                <order>random</order>
+                <ignoreDelete>false</ignoreDelete>
+                <scanProgressIntervalS>0</scanProgressIntervalS>
+                <pullerPauseS>0</pullerPauseS>
+                <maxConflicts>10</maxConflicts>
+                <disableSparseFiles>false</disableSparseFiles>
+                <disableTempIndexes>false</disableTempIndexes>
+                <paused>false</paused>
+                <weakHashThresholdPct>25</weakHashThresholdPct>
+                <markerName>.stfolder</markerName>
+                <copyOwnershipFromParent>false</copyOwnershipFromParent>
+                <modTimeWindowS>0</modTimeWindowS>
+                <maxConcurrentWrites>2</maxConcurrentWrites>
+                <disableFsync>false</disableFsync>
+                <blockPullOrder>standard</blockPullOrder>
+                <copyRangeMethod>standard</copyRangeMethod>
+                <caseSensitiveFS>false</caseSensitiveFS>
+                <junctionsAsDirs>false</junctionsAsDirs>
+            </folder>
+            <device id="" compression="metadata" introducer="false" skipIntroductionRemovals="false" introducedBy="">
+                <address>dynamic</address>
+                <paused>false</paused>
+                <autoAcceptFolders>false</autoAcceptFolders>
+                <maxSendKbps>0</maxSendKbps>
+                <maxRecvKbps>0</maxRecvKbps>
+                <maxRequestKiB>0</maxRequestKiB>
+                <untrusted>false</untrusted>
+                <remoteGUIPort>0</remoteGUIPort>
+            </device>
+        </defaults>
     </configuration>
 
 Configuration Element
@@ -169,14 +230,14 @@ Configuration Element
 
 .. code-block:: xml
 
-    <configuration version="30">
+    <configuration version="35">
         <folder></folder>
         <device></device>
         <gui></gui>
         <ldap></ldap>
         <options></options>
-        <ignoredDevice>5SYI2FS-LW6YAXI-JJDYETS-NDBBPIO-256MWBO-XDPXWVG-24QPUM4-PDW4UQU</ignoredDevice>
-        <ignoredFolder>bd7q3-zskm5</ignoredFolder>
+        <remoteIgnoredDevice></remoteIgnoredDevice>
+	<defaults></defaults>
     </configuration>
 
 This is the root element. It has one attribute:
@@ -185,18 +246,13 @@ version
     The config version. Increments whenever a change is made that requires
     migration from previous formats.
 
-It contains the elements described in the following sections and these two
-additional child elements:
+It contains the elements described in the following sections and any number of
+this additional child element:
 
-ignoredDevice
+remoteIgnoredDevice
     Contains the ID of the device that should be ignored. Connection attempts
     from this device are logged to the console but never displayed in the web
     GUI.
-
-ignoredFolder
-    Contains the ID of the folder that should be ignored. This folder will
-    always be skipped when advertised from a remote device, i.e. this will be
-    logged, but there will be no dialog shown in the web GUI.
 
 
 Folder Element
@@ -206,9 +262,15 @@ Folder Element
 
     <folder id="default" label="Default Folder" path="/Users/jb/Sync/" type="sendreceive" rescanIntervalS="3600" fsWatcherEnabled="true" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
         <filesystemType>basic</filesystemType>
-        <device id="3LT2GA5-CQI4XJM-WTZ264P-MLOGMHL-MCRLDNT-MZV4RD3-KA745CL-OGAERQZ"></device>
+        <device id="S7UKX27-GI7ZTXS-GC6RKUA-7AJGZ44-C6NAYEB-HSKTJQK-KJHU2NO-CWV7EQW" introducedBy="">
+            <encryptionPassword></encryptionPassword>
+        </device>
         <minDiskFree unit="%">1</minDiskFree>
-        <versioning></versioning>
+        <versioning>
+            <cleanupIntervalS>3600</cleanupIntervalS>
+            <fsPath></fsPath>
+            <fsType>basic</fsType>
+        </versioning>
         <copiers>0</copiers>
         <pullerMaxPendingKiB>0</pullerMaxPendingKiB>
         <hashers>0</hashers>
@@ -228,6 +290,8 @@ Folder Element
         <disableFsync>false</disableFsync>
         <blockPullOrder>standard</blockPullOrder>
         <copyRangeMethod>standard</copyRangeMethod>
+        <caseSensitiveFS>false</caseSensitiveFS>
+        <junctionsAsDirs>true</junctionsAsDirs>
     </folder>
 
 One or more ``folder`` elements must be present in the file. Each element
@@ -433,16 +497,18 @@ Device Element
 
 .. code-block:: xml
 
-    <device id="5SYI2FS-LW6YAXI-JJDYETS-NDBBPIO-256MWBO-XDPXWVG-24QPUM4-PDW4UQU" name="syno" compression="metadata" introducer="false" skipIntroductionRemovals="false" introducedBy="2CYF2WQ-AKZO2QZ-JAKWLYD-AGHMQUM-BGXUOIS-GYILW34-HJG3DUK-LRRYQAR">
+    <device id="S7UKX27-GI7ZTXS-GC6RKUA-7AJGZ44-C6NAYEB-HSKTJQK-KJHU2NO-CWV7EQW" name="syno" compression="metadata" introducer="false" skipIntroductionRemovals="false" introducedBy="2CYF2WQ-AKZO2QZ-JAKWLYD-AGHMQUM-BGXUOIS-GYILW34-HJG3DUK-LRRYQAR">
         <address>dynamic</address>
         <paused>false</paused>
         <autoAcceptFolders>false</autoAcceptFolders>
         <maxSendKbps>0</maxSendKbps>
         <maxRecvKbps>0</maxRecvKbps>
+        <ignoredFolder time="2022-01-09T19:09:52Z" id="br63e-wyhb7" label="Foo"></ignoredFolder>
         <maxRequestKiB>0</maxRequestKiB>
+        <untrusted>false</untrusted>
         <remoteGUIPort>0</remoteGUIPort>
     </device>
-    <device id="2CYF2WQ-AKZO2QZ-JAKWLYD-AGHMQUM-BGXUOIS-GYILW34-HJG3DUK-LRRYQAR" name="syno local" compression="metadata" introducer="false" skipIntroductionRemovals="false" introducedBy="">
+    <device id="2CYF2WQ-AKZO2QZ-JAKWLYD-AGHMQUM-BGXUOIS-GYILW34-HJG3DUK-LRRYQAR" name="syno local" compression="metadata" introducer="true" skipIntroductionRemovals="false" introducedBy="">
         <address>tcp://192.0.2.1:22001</address>
         <paused>true</paused>
         <allowedNetwork>192.168.0.0/16</allowedNetwork>
@@ -450,6 +516,7 @@ Device Element
         <maxSendKbps>100</maxSendKbps>
         <maxRecvKbps>100</maxRecvKbps>
         <maxRequestKiB>65536</maxRequestKiB>
+        <untrusted>false</untrusted>
         <remoteGUIPort>8384</remoteGUIPort>
     </device>
 
@@ -560,6 +627,11 @@ maxRecvKbps
     Maximum receive rate to use for this device. Unit is kibibytes/second,
     despite the config name looking like kilobits/second.
 
+ignoredFolder
+    Contains the ID of the folder that should be ignored. This folder will
+    always be skipped when advertised from the containing remote device,
+    i.e. this will be logged, but there will be no dialog shown in the web GUI.
+
 maxRequestKiB
     Maximum amount of data to have outstanding in requests towards this device.
     Unit is kibibytes.
@@ -579,7 +651,7 @@ GUI Element
 
     <gui enabled="true" tls="false" debugging="false">
         <address>127.0.0.1:8384</address>
-        <apikey>l7jSbCqPD95JYZ0g8vi4ZLAMg3ulnN1b</apikey>
+        <apikey>k1dnz1Dd0rzTBjjFFh7CXPnrF12C49B1</apikey>
         <theme>default</theme>
     </gui>
 
@@ -649,7 +721,7 @@ authMode
         LDAP authentication. Requires ldap top level config section to be present.
 
 LDAP Element
----------------
+------------
 
 .. code-block:: xml
 
@@ -722,8 +794,8 @@ Options Element
         <releasesURL>https://upgrades.syncthing.net/meta.json</releasesURL>
         <overwriteRemoteDeviceNamesOnConnect>false</overwriteRemoteDeviceNamesOnConnect>
         <tempIndexMinBlocks>10</tempIndexMinBlocks>
+        <unackedNotificationID>authenticationUserAndPassword</unackedNotificationID>
         <trafficClass>0</trafficClass>
-        <defaultFolderPath>~</defaultFolderPath>
         <setLowPriority>true</setLowPriority>
         <maxFolderConcurrency>0</maxFolderConcurrency>
         <crashReportingURL>https://crash.syncthing.net/newcrash</crashReportingURL>
@@ -733,6 +805,11 @@ Options Element
         <stunServer>default</stunServer>
         <databaseTuning>auto</databaseTuning>
         <maxConcurrentIncomingRequestKiB>0</maxConcurrentIncomingRequestKiB>
+        <announceLANAddresses>true</announceLANAddresses>
+        <sendFullIndexOnUpgrade>false</sendFullIndexOnUpgrade>
+        <connectionLimitEnough>0</connectionLimitEnough>
+        <connectionLimitMax>0</connectionLimitMax>
+        <insecureAllowOldTLSVersions>false</insecureAllowOldTLSVersions>
     </options>
 
 The ``options`` element contains all other global configuration options.
@@ -892,10 +969,6 @@ stunKeepaliveSeconds
     maintain NAT mapping. Default is ``24`` and you can set it to ``0`` to
     disable contacting STUN servers.
 
-defaultFolderPath
-    The UI will propose to create new folders at this path. This can be disabled by
-    setting this to an empty string.
-
 .. _set-low-priority:
 
 setLowPriority
@@ -906,6 +979,79 @@ setLowPriority
     to nine; on Windows, set the process priority class to below normal. To
     disable this behavior, for example to control process priority yourself
     as part of launching Syncthing, set this option to ``false``.
+
+Defaults Element
+----------------
+
+.. code-block:: xml
+
+    <defaults>
+        <folder id="" label="" path="~" type="sendreceive" rescanIntervalS="3600" fsWatcherEnabled="true" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
+            <filesystemType>basic</filesystemType>
+            <device id="S7UKX27-GI7ZTXS-GC6RKUA-7AJGZ44-C6NAYEB-HSKTJQK-KJHU2NO-CWV7EQW" introducedBy="">
+                <encryptionPassword></encryptionPassword>
+            </device>
+            <minDiskFree unit="%">1</minDiskFree>
+            <versioning>
+                <cleanupIntervalS>3600</cleanupIntervalS>
+                <fsPath></fsPath>
+                <fsType>basic</fsType>
+            </versioning>
+            <copiers>0</copiers>
+            <pullerMaxPendingKiB>0</pullerMaxPendingKiB>
+            <hashers>0</hashers>
+            <order>random</order>
+            <ignoreDelete>false</ignoreDelete>
+            <scanProgressIntervalS>0</scanProgressIntervalS>
+            <pullerPauseS>0</pullerPauseS>
+            <maxConflicts>10</maxConflicts>
+            <disableSparseFiles>false</disableSparseFiles>
+            <disableTempIndexes>false</disableTempIndexes>
+            <paused>false</paused>
+            <weakHashThresholdPct>25</weakHashThresholdPct>
+            <markerName>.stfolder</markerName>
+            <copyOwnershipFromParent>false</copyOwnershipFromParent>
+            <modTimeWindowS>0</modTimeWindowS>
+            <maxConcurrentWrites>2</maxConcurrentWrites>
+            <disableFsync>false</disableFsync>
+            <blockPullOrder>standard</blockPullOrder>
+            <copyRangeMethod>standard</copyRangeMethod>
+            <caseSensitiveFS>false</caseSensitiveFS>
+            <junctionsAsDirs>false</junctionsAsDirs>
+        </folder>
+        <device id="" compression="metadata" introducer="false" skipIntroductionRemovals="false" introducedBy="">
+            <address>dynamic</address>
+            <paused>false</paused>
+            <autoAcceptFolders>false</autoAcceptFolders>
+            <maxSendKbps>0</maxSendKbps>
+            <maxRecvKbps>0</maxRecvKbps>
+            <maxRequestKiB>0</maxRequestKiB>
+            <untrusted>false</untrusted>
+            <remoteGUIPort>0</remoteGUIPort>
+        </device>
+    </defaults>
+
+The ``defaults`` element describes a template for newly added device and folder
+options.  These will be used when adding a new remote device or folder, either
+through the GUI or the command line interface.  The following child elements can
+be present in the ``defaults`` element:
+
+device
+    Template for a ``device`` element, with the same internal structure.  Any
+    fields here will be used for a newly added remote device.  The ``id``
+    attribute is meaningless in this context.
+
+folder
+    Template for a ``folder`` element, with the same internal structure.  Any
+    fields here will be used for a newly added shared folder.  The ``id``
+    attribute is meaningless in this context.
+
+    The UI will propose to create new folders at the path given by the ``path``
+    attribute (used to be ``defaultFolderPath`` under ``options``).  It also
+    applies for automatically accepted folders from a remote device.
+
+    Even sharing with other remote devices can be done in the template by
+    including the appropriate ``device`` element underneath.
 
 .. _listen-addresses:
 

--- a/users/config.rst
+++ b/users/config.rst
@@ -107,7 +107,7 @@ The following shows an example of a default configuration file (IDs will differ)
             <blockPullOrder>standard</blockPullOrder>
             <copyRangeMethod>standard</copyRangeMethod>
             <caseSensitiveFS>false</caseSensitiveFS>
-            <junctionsAsDirs>true</junctionsAsDirs>
+            <junctionsAsDirs>false</junctionsAsDirs>
         </folder>
         <device id="S7UKX27-GI7ZTXS-GC6RKUA-7AJGZ44-C6NAYEB-HSKTJQK-KJHU2NO-CWV7EQW" name="syno" compression="metadata" introducer="false" skipIntroductionRemovals="false" introducedBy="">
             <address>dynamic</address>
@@ -291,7 +291,7 @@ Folder Element
         <blockPullOrder>standard</blockPullOrder>
         <copyRangeMethod>standard</copyRangeMethod>
         <caseSensitiveFS>false</caseSensitiveFS>
-        <junctionsAsDirs>true</junctionsAsDirs>
+        <junctionsAsDirs>false</junctionsAsDirs>
     </folder>
 
 One or more ``folder`` elements must be present in the file. Each element


### PR DESCRIPTION
Concerns the following fields changed in recent versions:

* encryptionPassword (added in folder)
* cleanupInterval, fsPath, fsType (added in folder versioning)
* caseSensitiveFS, junctionsAsDirs (added in folder)
* ignoredFolder (moved from configuration to device element)
* untrusted (added under device)
* unackedNotificationID (previously not in example)
* defaultFolderPath (moved from options to defaults)
* announceLANAddresses (added in options)
* sendFullIndexOnUpgrade (added in options)
* connectionLimitEnough (added in options)
* connectionLimitMax (added in options)
* insecureAllowOldTLSVersions (added in options)
* remoteIgnoredDevice (renamed from ignoredDevice under configuration)

Added the whole defaults section with an appropriate short
description.

Not all added options in the example have a description yet.

Change the GET /rest/system/config response to mostly match the
example XML listed in the config.xml description (except for skipping
device IDs).