### PR TITLE
users/config: Structured option documentation.

### DIFF
--- a/_ext/syncthing_config.py
+++ b/_ext/syncthing_config.py
@@ -7,6 +7,7 @@ Modeled after the standard :directive:`cmdoption` directive.
 from typing import Tuple, Dict, Iterator, Set, NamedTuple
 
 from docutils.nodes import Element
+from docutils.parsers.rst import directives
 from sphinx import addnodes
 from sphinx.addnodes import pending_xref
 from sphinx.builders import Builder
@@ -54,6 +55,9 @@ class ConfigOptionDirective(ObjectDescription):
 
     has_content = True
     required_arguments = 1
+    option_spec = {
+        'mandatory': directives.unchanged,
+    }
 
     def handle_signature(self, sig, signode) -> Tuple[str, str]:
         parts = sig.split(sep='.', maxsplit=1)
@@ -62,6 +66,13 @@ class ConfigOptionDirective(ObjectDescription):
         else:
             section, option = '', sig
         signode += addnodes.desc_name(text=option)
+        if 'mandatory' in self.options:
+            annotation = self.options['mandatory']
+            if annotation:
+                annotation = ' (mandatory: {})'.format(annotation)
+            else:
+                annotation = ' (mandatory)'
+            signode += addnodes.desc_annotation(annotation, annotation)
         return section, option
 
     def add_target_and_index(self, name, sig, signode):

--- a/_ext/syncthing_config.py
+++ b/_ext/syncthing_config.py
@@ -1,0 +1,131 @@
+"""
+Sphinx extension to provide link anchors for configuration options.
+
+Modeled after the standard :directive:`cmdoption` directive.
+"""
+
+from typing import Tuple, Dict, Iterator, Set
+
+from docutils.nodes import Element
+from sphinx import addnodes
+from sphinx.addnodes import pending_xref
+from sphinx.builders import Builder
+from sphinx.directives import ObjectDescription
+from sphinx.domains import Domain, ObjType
+from sphinx.environment import BuildEnvironment
+from sphinx.roles import XRefRole
+from sphinx.util.nodes import make_refnode
+
+
+__licence__ = 'BSD (3 clause)'
+
+
+class ConfigOptionRole(XRefRole):
+    """Name of a configuration option, with automatic cross-reference."""
+
+    def process_link(self, env: BuildEnvironment, refnode: Element,
+                     has_explicit_title: bool, title: str, target: str) -> Tuple[str, str]:
+        if not has_explicit_title:
+            target = target.lstrip('~')  # only has a meaning for the title
+            # if the first character is a tilde, don't display the section part of the contents
+            if title[0:1] == '~':
+                title = title[1:]
+                dot = title.rfind('.')
+                if dot != -1:
+                    title = title[dot + 1:]
+        return title, target
+
+
+class ConfigOptionDirective(ObjectDescription):
+    """Name of a configuration option, usable as an external link target."""
+
+    has_content = True
+    required_arguments = 1
+
+    def handle_signature(self, sig, signode) -> Tuple[str, str]:
+        parts = sig.split(sep='.', maxsplit=1)
+        if len(parts) > 1:
+            section, option = parts
+        else:
+            section, option = '', sig
+        signode += addnodes.desc_name(text=option)
+        return section, option
+
+    def add_target_and_index(self, name, sig, signode):
+        anchor = 'config-option-%s' % sig.lower()
+        signode['ids'].append(anchor)
+        config = self.env.get_domain('stconf')
+        config.add_config_option(sig, *name, anchor)
+
+
+class SyncthingConfigDomain(Domain):
+    """Custom domain to group information regarding Syncthing's configuration."""
+
+    name = 'stconf'
+    label = 'Syncthing Configuration'
+    directives = {
+        'option': ConfigOptionDirective,
+    }
+    roles = {
+        'opt': ConfigOptionRole(),
+    }
+    object_types = {
+        'option': ObjType('option', 'opt'),
+    }
+    initial_data = {
+        'sections': set(),  # string list
+        'options': {},  # fullname -> docname, objtype
+    }
+
+    @property
+    def config_sections(self) -> Set[str]:
+        return self.data.setdefault('sections', [])
+
+    @property
+    def config_options(self) -> Dict[str, Tuple]:
+        return self.data.setdefault('options', {})  # fullname -> (docname, node_id)
+
+    def get_full_qualified_name(self, node):  # FIXME: what is this for?!
+        return '{}.{}'.format('stconf-opt', node.arguments[0])
+
+    def get_objects(self) -> Iterator[Tuple[str, str, str, str, str, int]]:
+        for obj in self.config_options.values():
+            yield obj
+
+    def resolve_xref(self, env: BuildEnvironment, fromdocname: str, builder: Builder,
+                     typ: str, target: str, node: pending_xref, contnode: Element
+                     ) -> Element:
+        searches = [target]
+        if '.' not in target:
+            searches += ['{}.{}'.format(section, target)
+                         for section in self.config_sections]
+        match = [(docname, anchor)
+                 for name, sig, typ, docname, anchor, prio
+                 in self.get_objects() if sig in searches]
+        match = list(match)
+
+        if len(match) > 0:
+            todocname = match[0][0]
+            targ = match[0][1]
+
+            return make_refnode(builder, fromdocname, todocname, targ,
+                                contnode, targ)
+        return None
+
+    def add_config_option(self, signature, section, option, anchor):
+        """Add a new option anchor to the domain."""
+        name = '{}.{}'.format('stconf-opt', signature)
+        if section:
+            self.config_sections.add(section)
+        # name, dispname, type, docname, anchor, priority
+        self.config_options[signature] = (
+            name, signature, 'option', self.env.docname, anchor, 0)
+
+
+def setup(app):
+    """Install the plugin.
+
+    :param app: Sphinx application context.
+    """
+    app.add_domain(SyncthingConfigDomain)
+    return

--- a/_static/custom.css
+++ b/_static/custom.css
@@ -88,3 +88,7 @@ dt {
   font-weight: bold;
 }
 
+/* Extra padding after configuration options in e.g. in users/config. */
+dl.option {
+    margin-bottom: 1em;
+}

--- a/advanced/folder-filesystem-type.rst
+++ b/advanced/folder-filesystem-type.rst
@@ -1,0 +1,42 @@
+filesystemType
+==============
+
+Syncthing has an internal abstraction for file system access with different
+available implementations.  They can be configured per folder, with the
+following possible values:
+
+``basic`` (default)
+    To be used if the folder is intended to store real data. Do not change
+    unless you are a developer and want to test things.
+
+``fake``
+    A fake file system type to be used for testing, e.g. when you want to create
+    a folder with a :abbr:`TB (Terabyte)` or more of random files that can be
+    synced somewhere, or an infinitely large folder to sync files into.
+
+    It has pseudorandom properties, i.e. data read from one fakefs can be
+    written into another fakefs, read back, and it will look consistent, without
+    any real data actually being stored.
+
+    To create an empty file system, use
+
+    .. code-block::
+
+        <folder id="default" path="whatever" ...>
+            <filesystemType>fake</filesystemType>
+
+    You can also specify that it should be prefilled with files,
+
+    .. code-block::
+
+       <folder id="default" path="whatever?size=2000000" ...>
+           <filesystemType>fake</filesystemType>
+
+    which will create a file system filled with 2 :abbr:`TB (Terabyte)` of
+    random data that can be scanned and synced. The prefilled data is based on a
+    deterministic seed, so you can index it, restart Syncthing, and the index
+    will still be correct for all the stored data.
+
+    Check the source of `fakefs.go
+    <https://github.com/syncthing/syncthing/blob/main/lib/fs/fakefs.go>`_ for
+    more options and details.

--- a/conf.py
+++ b/conf.py
@@ -34,6 +34,7 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.extlinks',
     'edit_on_github',
+    'syncthing_config',
     'sphinx.ext.graphviz',
 ]
 

--- a/users/config.rst
+++ b/users/config.rst
@@ -1210,7 +1210,7 @@ The ``options`` element contains all other global configuration options.
 
 .. option:: options.sendFullIndexOnUpgrade
 
-    Controls whether all index data is resent when an upgrade is detected,
+    Controls whether all index data is resent when an upgrade has happened,
     equivalent to starting Syncthing with :option:`--reset-deltas`.  This used
     to be the default behavior in older versions, but is mainly useful as a
     troubleshooting step and causes high database churn. The default is now

--- a/users/config.rst
+++ b/users/config.rst
@@ -344,12 +344,10 @@ element:
 
     If set to ``true``, this detects changes to files in the folder and scans them.
 
-.. _fsWatcherDelayS:
-
 .. option:: folder.fsWatcherDelayS
 
     The duration during which changes detected are accumulated, before a scan is
-    scheduled (only takes effect if ``fsWatcherEnabled`` is set to ``true``).
+    scheduled (only takes effect if :opt:`fsWatcherEnabled` is set to ``true``).
 
 .. option:: folder.ignorePerms
 
@@ -1069,7 +1067,6 @@ The ``options`` element contains all other global configuration options.
     maintain NAT mapping. Default is ``24`` and you can set it to ``0`` to
     disable contacting STUN servers.
 
-.. _set-low-priority:
 
 .. option:: options.setLowPriority
 
@@ -1154,7 +1151,7 @@ be present in the ``defaults`` element:
     applies to folders automatically accepted from a remote device.
 
     Even sharing with other remote devices can be done in the template by
-    including the appropriate ``device`` element underneath.
+    including the appropriate :opt:`folder.device` element underneath.
 
 .. _listen-addresses:
 

--- a/users/config.rst
+++ b/users/config.rst
@@ -346,6 +346,10 @@ element:
         The folder is in "receive only" mode -- it will not propagate
         changes to other devices.
 
+    ``receiveencrypted``
+        Must be used on untrusted devices, where the data cannot be decrypted
+        because no folder password was entered.  See :doc:`untrusted`.
+
 .. option:: folder.rescanIntervalS
 
     The rescan interval, in seconds. Can be set to ``0`` to disable when external
@@ -751,8 +755,9 @@ From the following child elements at least one ``address`` child must exist.
 
     This boolean value marks a particular device as untrusted, which disallows
     ever sharing any unencrypted data with it.  Every folder shared with that
-    device then needs an encryption password set.  Refer to the detailed
-    explanation under :doc:`untrusted`.
+    device then needs an encryption password set, or must already be of the
+    "receive encrypted" type locally.  Refer to the detailed explanation under
+    :doc:`untrusted`.
 
 
 GUI Element

--- a/users/config.rst
+++ b/users/config.rst
@@ -420,8 +420,9 @@ The following child elements may exist:
 
 .. option:: folder.pullerMaxPendingKiB
 
-    The number of pullers is automatically adjusted based on this desired amount
-    of outstanding request data.
+    Controls when we stop sending requests to other devices once we’ve got this
+    much unserved requests.  The number of pullers is automatically adjusted
+    based on this desired amount of outstanding request data.
 
 .. option:: folder.order
 
@@ -563,8 +564,8 @@ The following child elements may exist:
 
 .. option:: folder.junctionsAsDirs
 
-    .. todo:: Describe element!
-    .. bool                               follow_junctions           = 34 [(ext.goname) = "JunctionsAsDirs", (ext.xml) = "junctionsAsDirs", (ext.json) = "junctionsAsDirs"];
+    NTFS directory junctions can be treated as ordinary directories, if this is
+    set to ``true``.
 
 
 Device Element
@@ -1210,13 +1211,16 @@ The ``options`` element contains all other global configuration options.
 
 .. option:: options.announceLANAddresses
 
-    .. todo:: Describe element!
-    .. bool            announce_lan_addresses                   = 48 [(ext.goname)= "AnnounceLANAddresses", (ext.xml) = "announceLANAddresses", (ext.json) = "announceLANAddresses", (ext.default) = "true"];
+    Enable (the default) or disable announcing private (RFC1918) LAN IP
+    addresses to global discovery.
 
 .. option:: options.sendFullIndexOnUpgrade
 
-    .. todo:: Describe element!
-    .. bool            send_full_index_on_upgrade               = 49;
+    Controls whether all index data is resent when an upgrade is detected,
+    equivalent to starting Syncthing with :option:`--reset-deltas`.  This used
+    to be the default behavior in previous versions, but is mainly useful as a
+    troubleshooting step and causes high database churn. The default is now
+    ``false``.
 
 .. option:: options.featureFlag
 

--- a/users/config.rst
+++ b/users/config.rst
@@ -384,7 +384,7 @@ The following child elements may exist:
     Specifies a versioning configuration.
 
     .. seealso::
-	:ref:`versioning`
+	:doc:`versioning`
 
 .. option:: folder.copiers
 	    folder.pullers
@@ -591,7 +591,7 @@ element:
     should copy their list of devices per folder when connecting.
 
     .. seealso::
-	:ref:`introducer`
+	:doc:`introducer`
 
 .. option:: device.skipIntroductionRemovals
 

--- a/users/config.rst
+++ b/users/config.rst
@@ -414,7 +414,7 @@ The following child elements may exist:
 	    folder.hashers
 
     The number of copier and hasher routines to use, or ``0`` for the
-    system determined optimums. These are low level performance options for
+    system determined optimums. These are low-level performance options for
     advanced users only; do not change unless requested to or you've actually
     read and understood the code yourself. :)
 
@@ -564,8 +564,8 @@ The following child elements may exist:
 
 .. option:: folder.junctionsAsDirs
 
-    NTFS directory junctions can be treated as ordinary directories, if this is
-    set to ``true``.
+    NTFS directory junctions are treated as ordinary directories, if this is set
+    to ``true``.
 
 
 Device Element
@@ -714,8 +714,9 @@ From the following child elements at least one ``address`` child must exist.
     and synced locally under the :opt:`default path <defaults.folder>`.  For the
     folder name, Syncthing tries to use the label from the remote device, and if
     the same label already exists, it then tries to use the folder's ID.  If
-    that exists as well, it just logs an error.  A local folder already added
-    with the same ID will just be shared rather than created separately.
+    that exists as well, the folder is just offered to accept manually.  A local
+    folder already added with the same ID will just be shared rather than
+    created separately.
 
 .. option:: device.maxSendKbps
 
@@ -1211,14 +1212,14 @@ The ``options`` element contains all other global configuration options.
 
     Controls whether all index data is resent when an upgrade is detected,
     equivalent to starting Syncthing with :option:`--reset-deltas`.  This used
-    to be the default behavior in previous versions, but is mainly useful as a
+    to be the default behavior in older versions, but is mainly useful as a
     troubleshooting step and causes high database churn. The default is now
     ``false``.
 
 .. option:: options.featureFlag
 
     Feature flags are simple strings that, when added to the configuration, may
-    unleash unfished or still-in-development features to allow early user
+    unleash unfinished or still-in-development features to allow early user
     testing.  Any supported value will be separately announced with the feature,
     so that regular users do not enable it by accident.
 
@@ -1238,8 +1239,8 @@ The ``options`` element contains all other global configuration options.
 
 .. option:: options.insecureAllowOldTLSVersions
 
-    Only for compatibility with old devices, as detailed in
-    :doc:`/advanced/option-insecure-allow-old-tls-versions`.
+    Only for compatibility with old versions of Syncthing on remote devices, as
+    detailed in :doc:`/advanced/option-insecure-allow-old-tls-versions`.
 
 
 Defaults Element

--- a/users/config.rst
+++ b/users/config.rst
@@ -383,8 +383,8 @@ The following child elements may exist:
 
     Specifies a versioning configuration.
 
-.. seealso::
-    :ref:`versioning`
+    .. seealso::
+	:ref:`versioning`
 
 .. option:: folder.copiers
 	    folder.pullers
@@ -590,8 +590,8 @@ element:
     Set to true if this device should be trusted as an introducer, i.e. we
     should copy their list of devices per folder when connecting.
 
-.. seealso::
-    :ref:`introducer`
+    .. seealso::
+	:ref:`introducer`
 
 .. option:: device.skipIntroductionRemovals
 

--- a/users/config.rst
+++ b/users/config.rst
@@ -430,8 +430,8 @@ The following child elements may exist:
 
 .. option:: folder.order
 
-    The order in which needed files should be pulled from the cluster.
-    The possibles values are:
+    The order in which needed files should be pulled from the cluster.  It has
+    no effect when the folder type is "send only".  The possibles values are:
 
     ``random`` (default)
         Pull files in random order. This optimizes for balancing resources among

--- a/users/config.rst
+++ b/users/config.rst
@@ -314,9 +314,8 @@ element:
 
 .. option:: folder.filesystemType
 
-    .. todo:: Document available filesystem types.
-    .. FILESYSTEM_TYPE_BASIC
-    .. FILESYSTEM_TYPE_FAKE
+    The internal file system implementation used to access this folder, detailed
+    in a :doc:`separate chapter </advanced/folder-filesystem-type>`.
 
 .. option:: folder.path
     :mandatory:
@@ -359,11 +358,17 @@ element:
 
 .. option:: folder.ignorePerms
 
-    True if the folder should ignore permissions.
+    If ``true``, files originating from this folder will be announced to remote
+    devices with the "no permission bits" flag.  The remote devices will use
+    whatever their default permission setting is when creating the files.  The
+    primary use case is for file systems that do not support permissions, such
+    as FAT, or environments where changing permissions is impossible.
 
 .. option:: folder.autoNormalize
 
-    Automatically correct UTF-8 normalization errors found in file names.
+    Automatically correct UTF-8 normalization errors found in file names.  The
+    mechanism and how to set it up is described in a :doc:`separate chapter
+    </advanced/folder-autonormalize>`.
 
 The following child elements may exist:
 
@@ -379,7 +384,10 @@ The following child elements may exist:
     Syncthing will currently add this automatically if it is not present in
     the configuration file.
 
-    .. todo:: Describe ``encryptionPassword`` sub-element!
+    The ``encryptionPassword`` sub-element contains the secret needed to decrypt
+    this folder's data on the remote device.  If left empty, the data is plainly
+    accessible (but still protected by the transport encryption).  The mechanism
+    and how to set it up is described in a :doc:`separate chapter <untrusted>`.
 
 .. option:: folder.minDiskFree
 
@@ -406,8 +414,8 @@ The following child elements may exist:
 
 .. option:: folder.pullerMaxPendingKiB
 
-    .. todo:: Describe element!
-    .. int32                              puller_max_pending_kib     = 15 [(ext.goname) = "PullerMaxPendingKiB", (ext.xml) = "pullerMaxPendingKiB", (ext.json) = "pullerMaxPendingKiB"];
+    The number of pullers is automatically adjusted based on this desired amount
+    of outstanding request data.
 
 .. option:: folder.order
 
@@ -439,7 +447,8 @@ The following child elements may exist:
         Enabling this is highly discouraged - use at your own risk. You have been warned.
 
     When set to ``true``, this device will pretend not to see instructions to
-    delete files from other devices.
+    delete files from other devices.  The mechanism is described in a
+    :doc:`separate chapter </advanced/folder-ignoredelete>`.
 
 .. option:: folder.scanProgressIntervalS
 
@@ -508,8 +517,9 @@ The following child elements may exist:
     .. warning::
         This is a known insecure option - use at your own risk.
 
-    Disables committing file operations to disk before recording them in the database.
-    Disabling fsync can lead to data corruption.
+    Disables committing file operations to disk before recording them in the
+    database.  Disabling fsync can lead to data corruption.  The mechanism is
+    described in a :doc:`separate chapter </advanced/folder-disable-fsync>`.
 
 .. option:: folder.blockPullOrder
 
@@ -533,16 +543,17 @@ The following child elements may exist:
 
 .. option:: folder.copyRangeMethod
 
-    Provides a choice of method for copying data between files. This can be used to optimise copies on network
-    filesystems, improve speed of large copies or clone the data using copy-on-write functionality if the underlying
-    filesystem supports it.
-
-    See :ref:`folder-copyRangeMethod` for details.
+    Provides a choice of method for copying data between files.  This can be
+    used to optimise copies on network filesystems, improve speed of large
+    copies or clone the data using copy-on-write functionality if the underlying
+    filesystem supports it.  The mechanism is described in a :doc:`separate
+    chapter </advanced/folder-copyrangemethod>`.
 
 .. option:: folder.caseSensitiveFS
 
-    .. todo:: Describe element!
-    .. bool                               case_sensitive_fs          = 33 [(ext.goname) = "CaseSensitiveFS", (ext.xml) = "caseSensitiveFS", (ext.json) = "caseSensitiveFS"];
+    Affects performance by disabling the extra safety checks for case
+    insensitive filesystems.  The mechanism and how to set it up is described in
+    a :doc:`separate chapter </advanced/folder-caseSensitiveFS>`.
 
 .. option:: folder.junctionsAsDirs
 
@@ -685,13 +696,18 @@ From the following child elements at least one ``address`` child must exist.
 
 .. option:: device.allowedNetwork
 
-    If given, this restricts connections to this device to only this network
-    (see :ref:`allowed-networks`).
+    If given, this restricts connections to this device to only this network.
+    The mechanism is described in detail in a :doc:`separate chapter
+    </advanced/device-allowednetworks>`).
 
 .. option:: device.autoAcceptFolders
 
-    .. todo:: Describe element!
-    .. bool                    auto_accept_folders        = 11;
+    If ``true``, folders shared from this remote device are automatically added
+    and synced locally under the :opt:`default path <defaults.folder>`.  For the
+    folder name, Syncthing tries to use the label from the remote device, and if
+    the same label already exists, it then tries to use the folder's ID.  If
+    that exists as well, it just logs an error.  A local folder already added
+    with the same ID will just be shared rather than created separately.
 
 .. option:: device.maxSendKbps
 
@@ -724,7 +740,10 @@ From the following child elements at least one ``address`` child must exist.
 
 .. option:: device.untrusted
 
-    .. todo:: Describe element!
+    This boolean value marks a particular device as untrusted, which disallows
+    ever sharing any unencrypted data with it.  Every folder shared with that
+    device then needs an encryption password set.  Refer to the detailed
+    explanation under :doc:`untrusted`.
 
 GUI Element
 -----------
@@ -801,11 +820,14 @@ The following child elements may be present:
 
 .. option:: gui.insecureSkipHostcheck
 
-    .. todo:: Describe element!
+    When the GUI / API is bound to localhost, we enforce that the ``Host``
+    header looks like localhost.  This option bypasses that check.
 
 .. option:: gui.insecureAllowFrameLoading
 
-    .. todo:: Describe element!
+    Allow rendering the GUI within an ``<iframe>``, ``<frame>`` or ``<object>``
+    by not setting the ``X-Frame-Options: SAMEORIGIN`` HTTP header.  This may be
+    needed for serving the Syncthing GUI as part of a website through a proxy.
 
 .. option:: gui.theme
 
@@ -834,13 +856,16 @@ LDAP Element
         <insecureSkipVerify>false</insecureSkipVerify>
     </ldap>
 
-The ``ldap`` element contains LDAP configuration options.
+The ``ldap`` element contains LDAP configuration options.  The mechanism is
+described in detail under :doc:`ldap`.
 
 .. option:: ldap.address
+   :mandatory:
 
     LDAP server address (server:port).
 
 .. option:: ldap.bindDN
+   :mandatory:
 
     BindDN for user authentication.
     Special ``%s`` variable should be used to pass username to LDAP.
@@ -862,13 +887,11 @@ The ``ldap`` element contains LDAP configuration options.
 
 .. option:: ldap.searchBaseDN
 
-    .. todo:: Describe element!
-    .. string        search_base_dn       = 5 [(ext.goname) = "SearchBaseDN", (ext.xml) = "searchBaseDN,omitempty", (ext.json) = "searchBaseDN"];
+    Base DN for user searches.
 
 .. option:: ldap.searchFilter
 
-    .. todo:: Describe element!
-    .. string        search_filter        = 6 [(ext.xml) = "searchFilter,omitempty"];
+    Search filter for user searches.
 
 Options Element
 ---------------
@@ -1146,28 +1169,34 @@ The ``options`` element contains all other global configuration options.
     disable this behavior, for example to control process priority yourself
     as part of launching Syncthing, set this option to ``false``.
 
+.. option:: options.maxFolderConcurrency
+
+    This option controls how many folders may concurrently be in I/O-intensive
+    operations such as syncing or scanning.  The mechanism is described in
+    detail in a :doc:`separate chapter </advanced/option-max-concurrency>`.
+
 .. option:: options.crashReportingURL
 
-    .. todo:: Describe element!
-    .. string          crash_reporting_url                      = 41 [(ext.goname) = "CRURL", (ext.xml) = "crashReportingURL", (ext.json) = "crURL", (ext.default) = "https://crash.syncthing.net/newcrash"];
+    Server URL where :doc:`automatic crash reports <crashrep>` will be sent if
+    enabled.
 
 .. option:: options.crashReportingEnabled
 
-    .. todo:: Describe element!
-    .. bool            crash_reporting_enabled                  = 42 [(ext.goname) = "CREnabled", (ext.default) = "true"];
+    Switch to opt out from the :doc:`automatic crash reporting <crashrep>`
+    feature to avoid Syncthing "phoning home" on serious troubles.  Defaults to
+    ``true``, to help the developers troubleshoot.
 
 .. option:: options.databaseTuning
 
-    .. todo:: Describe element!
-    .. Tuning          database_tuning                          = 46 [(ext.restart) = true];
-    .. TUNING_AUTO  = 0;
-    .. TUNING_SMALL = 1;
-    .. TUNING_LARGE = 2;
+    Controls how Syncthing uses the backend key-value database that stores the
+    index data and other persistent data it needs.  The available options and
+    implications are explained in a :doc:`separate chapter
+    </advanced/option-database-tuning>`.
 
 .. option:: options.maxConcurrentIncomingRequestKiB
 
-    .. todo:: Describe element!
-    .. int32           max_concurrent_incoming_request_kib      = 47 [(ext.goname) = "RawMaxCIRequestKiB", (ext.xml) = "maxConcurrentIncomingRequestKiB", (ext.json) = "maxConcurrentIncomingRequestKiB"];
+    This limits how many bytes we have "in the air" in the form of response data
+    being read and processed.
 
 .. option:: options.announceLANAddresses
 
@@ -1187,18 +1216,21 @@ The ``options`` element contains all other global configuration options.
 .. option:: options.connectionLimitEnough
 
     The number of connections at which we stop trying to connect to more
-    devices, zero meaning no limit. Does not affect incoming connections.
+    devices, zero meaning no limit.  Does not affect incoming connections.  The
+    mechanism is described in detail in a :doc:`separate chapter
+    </advanced/option-connection-limits>`.
 
 .. option:: options.connectionLimitMax
 
     The maximum number of connections which we will allow in total, zero meaning
-    no limit. Affects incoming connections and prevents attempting outgoing
-    connections.
+    no limit.  Affects incoming connections and prevents attempting outgoing
+    connections.  The mechanism is described in detail in a :doc:`separate
+    chapter </advanced/option-connection-limits>`.
 
 .. option:: options.insecureAllowOldTLSVersions
 
-    .. todo:: Describe element!
-    .. bool insecure_allow_old_tls_versions = 53 [(ext.goname)= "InsecureAllowOldTLSVersions", (ext.xml) = "insecureAllowOldTLSVersions", (ext.json) = "insecureAllowOldTLSVersions"];
+    Only for compatibility with old devices, as detailed in
+    :doc:`/advanced/option-insecure-allow-old-tls-versions`.
 
 Defaults Element
 ----------------

--- a/users/config.rst
+++ b/users/config.rst
@@ -1224,8 +1224,10 @@ The ``options`` element contains all other global configuration options.
 
 .. option:: options.featureFlag
 
-    .. todo:: Describe element!
-    .. repeated string feature_flags                            = 50;
+    Feature flags are simple strings that, when added to the configuration, may
+    unleash unfished or still-in-development features to allow early user
+    testing.  Any supported value will be separately announced with the feature,
+    so that regular users do not enable it by accident.
 
 .. option:: options.connectionLimitEnough
 

--- a/users/config.rst
+++ b/users/config.rst
@@ -327,18 +327,18 @@ element:
 
     Controls how the folder is handled by Syncthing. Possible values are:
 
-    sendreceive
+    ``sendreceive``
         The folder is in default mode. Sending local and accepting remote changes.
         Note that this type was previously called "readwrite" which is deprecated
         but still accepted in incoming configs.
 
-    sendonly
+    ``sendonly``
         The folder is in "send only" mode -- it will not be modified by
         Syncthing on this device.
         Note that this type was previously called "readonly" which is deprecated
         but still accepted in incoming configs.
 
-    receiveonly
+    ``receiveonly``
         The folder is in "receive only" mode -- it will not propagate
         changes to other devices.
 
@@ -374,10 +374,12 @@ The following child elements may exist:
 
 .. option:: folder.device
 
-    These must have the ``id`` attribute and can have an ``introducedBy`` attribute,
-    identifying the device that introduced us to share this folder with the given device.
-    If the original introducer unshares this folder with this device, our device will follow
-    and unshare the folder (subject to skipIntroductionRemovals being false on the introducer device).
+    These must have the ``id`` attribute and can have an ``introducedBy``
+    attribute, identifying the device that introduced us to share this folder
+    with the given device.  If the original introducer unshares this folder with
+    this device, our device will follow and unshare the folder (subject to
+    :opt:`skipIntroductionRemovals` being ``false`` on the introducer device).
+
     All mentioned devices are those that will be sharing the folder in question.
     Each mentioned device must have a separate ``device`` element later in the file.
     It is customary that the local device ID is included in all folders.
@@ -422,17 +424,17 @@ The following child elements may exist:
     The order in which needed files should be pulled from the cluster.
     The possibles values are:
 
-    random
+    ``random``
         Pull files in random order. This optimizes for balancing resources among
         the devices in a cluster.
 
-    alphabetic
+    ``alphabetic``
         Pull files ordered by file name alphabetically.
 
-    smallestFirst, largestFirst
+    ``smallestFirst``, ``largestFirst``
         Pull files ordered by file size; smallest and largest first respectively.
 
-    oldestFirst, newestFirst
+    ``oldestFirst``, ``newestFirst``
         Pull files ordered by modification time; oldest and newest first
         respectively.
 
@@ -528,16 +530,16 @@ The following child elements may exist:
 
     Available options:
 
-    standard (default):
+    ``standard`` (default)
         The blocks of a file are split into N equal continuous sequences, where N is the number of connected
         devices. Each device starts downloading its own sequence, after which it picks other devices
         sequences at random. Provides acceptable data distribution and minimal spinning disk strain.
 
-    random:
+    ``random``
         The blocks of a file are downloaded in a random order. Provides great data distribution, but very taxing on
         spinning disk drives.
 
-    inOrder:
+    ``inOrder``
         The blocks of a file are downloaded sequentially, from start to finish. Spinning disk drive friendly, but provides
         no improvements to data distribution.
 
@@ -608,16 +610,16 @@ element:
     Whether to use protocol compression when sending messages to this device.
     The possible values are:
 
-    metadata
+    ``metadata``
         Compress metadata packets, such as index information. Metadata is
         usually very compression friendly so this is a good default.
 
-    always
+    ``always``
         Compress all packets, including file data. This is recommended if the
         folders contents are mainly compressible data such as documents or
         text files.
 
-    never
+    ``never``
         Disable all compression.
 
 .. option:: device.introducer
@@ -838,10 +840,10 @@ The following child elements may be present:
     Authentication mode to use. If not present, the authentication mode (static)
     is controlled by the presence of user/password fields for backward compatibility.
 
-    static
+    ``static``
         Authentication using user and password.
 
-    ldap
+    ``ldap``
         LDAP authentication. Requires ldap top level config section to be present.
 
 LDAP Element
@@ -872,13 +874,13 @@ described in detail under :doc:`ldap`.
 
 .. option:: ldap.transport
 
-    nontls
+    ``nontls``
         Non secure connection.
 
-    tls
+    ``tls``
         TLS secured connection.
 
-    starttls
+    ``starttls``
         StartTLS connection mode.
 
 .. option:: ldap.insecureSkipVerify

--- a/users/config.rst
+++ b/users/config.rst
@@ -428,7 +428,7 @@ The following child elements may exist:
     The order in which needed files should be pulled from the cluster.
     The possibles values are:
 
-    ``random``
+    ``random`` (default)
         Pull files in random order. This optimizes for balancing resources among
         the devices in a cluster.
 

--- a/users/config.rst
+++ b/users/config.rst
@@ -1,3 +1,5 @@
+.. default-domain:: stconf
+
 .. _config:
 
 Syncthing Configuration
@@ -242,18 +244,19 @@ Configuration Element
 
 This is the root element. It has one attribute:
 
-version
+.. option:: configuration.version
+
     The config version. Increments whenever a change is made that requires
     migration from previous formats.
 
 It contains the elements described in the following sections and any number of
 this additional child element:
 
-remoteIgnoredDevice
+.. option:: configuration.remoteIgnoredDevice
+
     Contains the ID of the device that should be ignored. Connection attempts
     from this device are logged to the console but never displayed in the web
     GUI.
-
 
 Folder Element
 --------------
@@ -298,19 +301,23 @@ One or more ``folder`` elements must be present in the file. Each element
 describes one folder. The following attributes may be set on the ``folder``
 element:
 
-id
+.. option:: folder.id
+
     The folder ID, which must be unique. (mandatory)
 
-label
+.. option:: folder.label
+
     The label of a folder is a human readable and descriptive local name. May
     be different on each device, empty, and/or identical to other folder
     labels. (optional)
 
-path
+.. option:: folder.path
+
     The path to the directory where the folder is stored on this
     device; not sent to other devices. (mandatory)
 
-type
+.. option:: folder.type
+
     Controls how the folder is handled by Syncthing. Possible values are:
 
     sendreceive
@@ -328,28 +335,34 @@ type
         The folder is in "receive only" mode -- it will not propagate
         changes to other devices.
 
-rescanIntervalS
+.. option:: folder.rescanIntervalS
+
     The rescan interval, in seconds. Can be set to ``0`` to disable when external
     plugins are used to trigger rescans.
 
-fsWatcherEnabled
+.. option:: folder.fsWatcherEnabled
+
     If set to ``true``, this detects changes to files in the folder and scans them.
 
 .. _fsWatcherDelayS:
 
-fsWatcherDelayS
+.. option:: folder.fsWatcherDelayS
+
     The duration during which changes detected are accumulated, before a scan is
     scheduled (only takes effect if ``fsWatcherEnabled`` is set to ``true``).
 
-ignorePerms
+.. option:: folder.ignorePerms
+
     True if the folder should ignore permissions.
 
-autoNormalize
+.. option:: folder.autoNormalize
+
     Automatically correct UTF-8 normalization errors found in file names.
 
 The following child elements may exist:
 
-device
+.. option:: folder.device
+
     These must have the ``id`` attribute and can have an ``introducedBy`` attribute,
     identifying the device that introduced us to share this folder with the given device.
     If the original introducer unshares this folder with this device, our device will follow
@@ -360,24 +373,30 @@ device
     Syncthing will currently add this automatically if it is not present in
     the configuration file.
 
-minDiskFree
+.. option:: folder.minDiskFree
+
     The minimum required free space that should be available on the disk this folder
     resides. The folder will be stopped when the value drops below the threshold. Accepted units are
     ``%``, ``kB``, ``MB``, ``GB`` and ``TB``. Set to zero to disable.
 
-versioning
+.. option:: folder.versioning
+
     Specifies a versioning configuration.
 
 .. seealso::
     :ref:`versioning`
 
-copiers, pullers, hashers
+.. option:: folder.copiers
+	    folder.pullers
+	    folder.hashers
+
     The number of copier, puller and hasher routines to use, or ``0`` for the
     system determined optimums. These are low level performance options for
     advanced users only; do not change unless requested to or you've actually
     read and understood the code yourself. :)
 
-order
+.. option:: folder.order
+
     The order in which needed files should be pulled from the cluster.
     The possibles values are:
 
@@ -400,65 +419,77 @@ order
     a 1 GB file even if there is 1 KB file available on the source device until
     the 1 KB becomes known to the pulling device.
 
-ignoreDelete
+.. option:: folder.ignoreDelete
+
     .. warning::
         Enabling this is highly discouraged - use at your own risk. You have been warned.
 
     When set to ``true``, this device will pretend not to see instructions to
     delete files from other devices.
 
-scanProgressIntervalS
+.. option:: folder.scanProgressIntervalS
+
     The interval in seconds with which scan progress information is sent to the GUI. Setting to ``0``
     will cause Syncthing to use the default value of two.
 
-pullerPauseS
+.. option:: folder.pullerPauseS
+
     Tweak for rate limiting the puller when it retries pulling files. Don't
     change this unless you know what you're doing.
 
-maxConflicts
+.. option:: folder.maxConflicts
+
     The maximum number of conflict copies to keep around for any given file.
     The default, ``-1``, means an unlimited number. Setting this to ``0`` disables
     conflict copies altogether.
 
-disableSparseFiles
+.. option:: folder.disableSparseFiles
+
     By default, blocks containing all zeros are not written, causing files
     to be sparse on filesystems that support this feature. When set to ``true``,
     sparse files will not be created.
 
-disableTempIndexes
+.. option:: folder.disableTempIndexes
+
     By default, devices exchange information about blocks available in
     transfers that are still in progress, which allows other devices to
     download parts of files that are not yet fully downloaded on your own
     device, essentially making transfers more torrent like. When set to
     ``true``, such information is not exchanged for this folder.
 
-paused
+.. option:: folder.paused
+
     True if this folder is (temporarily) suspended.
 
-weakHashThresholdPct
+.. option:: folder.weakHashThresholdPct
+
     Use weak hash if more than the given percentage of the file has changed. Set
     to ``-1`` to always use weak hash. Default is ``25``.
 
-markerName
+.. option:: folder.markerName
+
     Name of a directory or file in the folder root to be used as
     :ref:`marker-faq`. Default is ``.stfolder``.
 
-copyOwnershipFromParent
+.. option:: folder.copyOwnershipFromParent
+
     On Unix systems, tries to copy file/folder ownership from the parent directory (the directory it's located in).
     Requires running Syncthing as a privileged user, or granting it additional capabilities (e.g. CAP_CHOWN on Linux).
 
-modTimeWindowS
+.. option:: folder.modTimeWindowS
+
     Allowed modification timestamp difference when comparing files for
     equivalence. To be used on file systems which have unstable
     modification timestamps that might change after being recorded
     during the last write operation. Default is ``2`` on Android when the
     folder is located on a FAT partition, and ``0`` otherwise.
 
-maxConcurrentWrites
+.. option:: folder.maxConcurrentWrites
+
     Maximum number of concurrent write operations while syncing. Increasing this might increase or
     decrease disk performance, depending on the underlying storage. Default is ``2``.
 
-disableFsync
+.. option:: folder.disableFsync
 
     .. warning::
         This is a known insecure option - use at your own risk.
@@ -466,7 +497,8 @@ disableFsync
     Disables committing file operations to disk before recording them in the database.
     Disabling fsync can lead to data corruption.
 
-blockPullOrder
+.. option:: folder.blockPullOrder
+
     Order in which the blocks of a file are downloaded. This option controls how quickly different parts of the
     file spread between the connected devices, at the cost of causing strain on the storage.
 
@@ -485,7 +517,8 @@ blockPullOrder
         The blocks of a file are downloaded sequentially, from start to finish. Spinning disk drive friendly, but provides
         no improvements to data distribution.
 
-copyRangeMethod
+.. option:: folder.copyRangeMethod
+
     Provides a choice of method for copying data between files. This can be used to optimise copies on network
     filesystems, improve speed of large copies or clone the data using copy-on-write functionality if the underlying
     filesystem supports it.
@@ -526,13 +559,16 @@ describes a device participating in the cluster. It is customary to include a
 it is not present. The following attributes may be set on the ``device``
 element:
 
-id
+.. option:: device.id
+
     The :ref:`device ID <device-ids>`. (mandatory)
 
-name
+.. option:: device.name
+
     A friendly name for the device. (optional)
 
-compression
+.. option:: device.compression
+
     Whether to use protocol compression when sending messages to this device.
     The possible values are:
 
@@ -548,27 +584,32 @@ compression
     never
         Disable all compression.
 
-introducer
+.. option:: device.introducer
+
     Set to true if this device should be trusted as an introducer, i.e. we
     should copy their list of devices per folder when connecting.
 
 .. seealso::
     :ref:`introducer`
 
-skipIntroductionRemovals
+.. option:: device.skipIntroductionRemovals
+
     Set to true if you wish to follow only introductions and not de-introductions.
     For example, if this is set, we would not remove a device that we were introduced
     to even if the original introducer is no longer listing the remote device as known.
 
-introducedBy
+.. option:: device.introducedBy
+
     Defines which device has introduced us to this device. Used only for following de-introductions.
 
-certName
+.. option:: device.certName
+
     The device certificate's common name, if it is not the default "syncthing".
 
 From the following child elements at least one ``address`` child must exist.
 
-address
+.. option:: device.address
+
     Contains an address or host name to use when attempting to connect to this device.
     Entries other than ``dynamic`` need a protocol specific prefix. For the TCP protocol
     the prefixes ``tcp://`` (dual-stack), ``tcp4://`` (IPv4 only) or ``tcp6://`` (IPv6 only) can be used.
@@ -612,31 +653,38 @@ address
             <address>dynamic</address>
         </device>
 
-paused
+.. option:: device.paused
+
     True if synchronization with this devices is (temporarily) suspended.
 
-allowedNetwork
+.. option:: device.allowedNetwork
+
     If given, this restricts connections to this device to only this network
     (see :ref:`allowed-networks`).
 
-maxSendKbps
+.. option:: device.maxSendKbps
+
     Maximum send rate to use for this device. Unit is kibibytes/second, despite
     the config name looking like kilobits/second.
 
-maxRecvKbps
+.. option:: device.maxRecvKbps
+
     Maximum receive rate to use for this device. Unit is kibibytes/second,
     despite the config name looking like kilobits/second.
 
-ignoredFolder
+.. option:: device.ignoredFolder
+
     Contains the ID of the folder that should be ignored. This folder will
     always be skipped when advertised from the containing remote device,
     i.e. this will be logged, but there will be no dialog shown in the web GUI.
 
-maxRequestKiB
+.. option:: device.maxRequestKiB
+
     Maximum amount of data to have outstanding in requests towards this device.
     Unit is kibibytes.
 
-remoteGUIPort
+.. option:: device.remoteGUIPort
+
     If set to a positive integer, the GUI will display an HTTP link to the IP
     address which is currently used for synchronization.  Only the TCP port is
     exchanged for the value specified here.  Note that any port forwarding or
@@ -660,20 +708,24 @@ There must be exactly one ``gui`` element. The GUI configuration is also used
 by the :ref:`rest-api` and the :ref:`event-api`. The following attributes may
 be set on the ``gui`` element:
 
-enabled
+.. option:: gui.enabled
+
     If not ``true``, the GUI and API will not be started.
 
-tls
+.. option:: gui.tls
+
     If set to ``true``, TLS (HTTPS) will be enforced. Non-HTTPS requests will
     be redirected to HTTPS. When set to ``false``, TLS connections are
     still possible but not required.
 
-debugging
+.. option:: gui.debugging
+
     This enables :ref:`profiling` and additional debugging endpoints in the :ref:`rest-api`.
 
 The following child elements may be present:
 
-address
+.. option:: gui.address
+
     Set the listen address. Exactly one address element must be present. Allowed address formats are:
 
     IPv4 address and port (``127.0.0.1:8384``)
@@ -690,27 +742,34 @@ address
     UNIX socket location (``/var/run/st.sock``)
         If the address is an absolute path it is interpreted as the path to a UNIX socket.
 
-unixSocketPermissions
+.. option:: gui.unixSocketPermissions
+
     When ``address`` is set to a UNIX socket location, set this to an octal value 
     to override the default permissions of the socket.
 
-user
+.. option:: gui.user
+
     Set to require authentication.
 
-password
+.. option:: gui.password
+
     Contains the bcrypt hash of the real password.
 
-apikey
+.. option:: gui.apikey
+
     If set, this is the API key that enables usage of the REST interface.
 
-insecureAdminAccess
+.. option:: gui.insecureAdminAccess
+
     If true, this allows access to the web GUI from outside (i.e. not localhost)
     without authorization. A warning will displayed about this setting on startup.
 
-theme
+.. option:: gui.theme
+
     The name of the theme to use.
 
-authMode
+.. option:: gui.authMode
+
     Authentication mode to use. If not present, the authentication mode (static)
     is controlled by the presence of user/password fields for backward compatibility.
 
@@ -734,14 +793,16 @@ LDAP Element
 
 The ``ldap`` element contains LDAP configuration options.
 
-address
+.. option:: ldap.address
+
     LDAP server address (server:port).
 
-bindDN
+.. option:: ldap.bindDN
+
     BindDN for user authentication.
     Special ``%s`` variable should be used to pass username to LDAP.
 
-transport
+.. option:: ldap.transport
 
     nontls
         Non secure connection.
@@ -752,7 +813,8 @@ transport
     starttls
         StartTLS connection mode.
 
-insecureSkipVerify
+.. option:: ldap.insecureSkipVerify
+
     Skip verification (``true`` or ``false``).
 
 Options Element
@@ -814,11 +876,13 @@ Options Element
 
 The ``options`` element contains all other global configuration options.
 
-listenAddress
+.. option:: options.listenAddress
+
     The listen address for incoming sync connections. See
     :ref:`listen-addresses` for the allowed syntax.
 
-globalAnnounceServer
+.. option:: options.globalAnnounceServer
+
     A URI to a global announce (discovery) server, or the word ``default`` to
     include the default servers. Any number of globalAnnounceServer elements
     may be present. The syntax for non-default entries is that of an HTTP or
@@ -827,133 +891,168 @@ globalAnnounceServer
     and ``id=<device ID>`` to perform certificate pinning. The device ID to
     use is printed by the discovery server on startup.
 
-globalAnnounceEnabled
+.. option:: options.globalAnnounceEnabled
+
     Whether to announce this device to the global announce (discovery) server,
     and also use it to look up other devices.
 
-localAnnounceEnabled
+.. option:: options.localAnnounceEnabled
+
     Whether to send announcements to the local LAN, also use such
     announcements to find other devices.
 
-localAnnouncePort
+.. option:: options.localAnnouncePort
+
     The port on which to listen and send IPv4 broadcast announcements to.
 
-localAnnounceMCAddr
+.. option:: options.localAnnounceMCAddr
+
     The group address and port to join and send IPv6 multicast announcements on.
 
-maxSendKbps
+.. option:: options.maxSendKbps
+
     Outgoing data rate limit, in kibibytes per second.
 
-maxRecvKbps
+.. option:: options.maxRecvKbps
+
     Incoming data rate limits, in kibibytes per second.
 
-reconnectionIntervalS
+.. option:: options.reconnectionIntervalS
+
     The number of seconds to wait between each attempt to connect to currently
     unconnected devices.
 
-relaysEnabled
+.. option:: options.relaysEnabled
+
     When ``true``, relays will be connected to and potentially used for device to device connections.
 
-relayReconnectIntervalM
+.. option:: options.relayReconnectIntervalM
+
     Sets the interval, in minutes, between relay reconnect attempts.
 
-startBrowser
+.. option:: options.startBrowser
+
     Whether to attempt to start a browser to show the GUI when Syncthing starts.
 
-natEnabled
+.. option:: options.natEnabled
+
     Whether to attempt to perform a UPnP and NAT-PMP port mapping for
     incoming sync connections.
 
-natLeaseMinutes
+.. option:: options.natLeaseMinutes
+
     Request a lease for this many minutes; zero to request a permanent lease.
 
-natRenewalMinutes
+.. option:: options.natRenewalMinutes
+
     Attempt to renew the lease after this many minutes.
 
-natTimeoutSeconds
+.. option:: options.natTimeoutSeconds
+
     When scanning for UPnP devices, wait this long for responses.
 
-urAccepted
+.. option:: options.urAccepted
+
     Whether the user has accepted to submit anonymous usage data. The default,
     ``0``, mean the user has not made a choice, and Syncthing will ask at some
     point in the future. ``-1`` means no, a number above zero means that that
     version of usage reporting has been accepted.
 
-urSeen
+.. option:: options.urSeen
+
     The highest usage reporting version that has already been shown in the web GUI.
 
-urUniqueID
+.. option:: options.urUniqueID
+
     The unique ID sent together with the usage report. Generated when usage
     reporting is enabled.
 
-urURL
+.. option:: options.urURL
+
     The URL to post usage report data to, when enabled.
 
-urPostInsecurely
+.. option:: options.urPostInsecurely
+
     When true, the UR URL can be http instead of https, or have a self-signed
     certificate. The default is ``false``.
 
-urInitialDelayS
+.. option:: options.urInitialDelayS
+
     The time to wait from startup for the first usage report to be sent. Allows
     the system to stabilize before reporting statistics.
 
-restartOnWakeup
+.. option:: options.restartOnWakeup
+
     Whether to perform a restart of Syncthing when it is detected that we are
     waking from sleep mode (i.e. an unfolding laptop).
 
-autoUpgradeIntervalH
+.. option:: options.autoUpgradeIntervalH
+
     Check for a newer version after this many hours. Set to ``0`` to disable
     automatic upgrades.
 
-upgradeToPreReleases
+.. option:: options.upgradeToPreReleases
+
     If ``true``, automatic upgrades include release candidates (see
     :ref:`releases`).
 
-keepTemporariesH
+.. option:: options.keepTemporariesH
+
     Keep temporary failed transfers for this many hours. While the temporaries
     are kept, the data they contain need not be transferred again.
 
-cacheIgnoredFiles
+.. option:: options.cacheIgnoredFiles
+
     Whether to cache the results of ignore pattern evaluation. Performance
     at the price of memory. Defaults to ``false`` as the cost for evaluating
     ignores is usually not significant.
 
-progressUpdateIntervalS
+.. option:: options.progressUpdateIntervalS
+
     How often in seconds the progress of ongoing downloads is made available to
     the GUI.
 
-limitBandwidthInLan
+.. option:: options.limitBandwidthInLan
+
     Whether to apply bandwidth limits to devices in the same broadcast domain
     as the local device.
 
-minHomeDiskFree
+.. option:: options.minHomeDiskFree
+
     The minimum required free space that should be available on the
     partition holding the configuration and index. Accepted units are ``%``, ``kB``,
     ``MB``, ``GB`` and ``TB``.
 
-releasesURL
+.. option:: options.releasesURL
+
     The URL from which release information is loaded, for automatic upgrades.
 
-alwaysLocalNet
+.. option:: options.alwaysLocalNet
+
     Network that should be considered as local given in CIDR notation.
 
-overwriteRemoteDeviceNamesOnConnect
+.. option:: options.overwriteRemoteDeviceNamesOnConnect
+
     If set, device names will always be overwritten with the name given by
     remote on each connection. By default, the name that the remote device
     announces will only be adopted when a name has not already been set.
 
-tempIndexMinBlocks
+.. option:: options.tempIndexMinBlocks
+
     When exchanging index information for incomplete transfers, only take
     into account files that have at least this many blocks.
 
-unackedNotificationID
+.. option:: options.unackedNotificationID
+
     ID of a notification to be displayed in the web GUI. Will be removed once
     the user acknowledged it (e.g. an transition notice on an upgrade).
 
-trafficClass
+.. option:: options.trafficClass
+
     Specify a type of service (TOS)/traffic class of outgoing packets.
 
-stunServer
+.. option:: options.stunServer
+
     Server to be used for STUN, given as ip:port. The keyword ``default`` gets
     expanded to
     ``stun.callwithus.com:3478``, ``stun.counterpath.com:3478``,
@@ -964,14 +1063,16 @@ stunServer
     ``stun.voiparound.com:3478``, ``stun.voipbuster.com:3478``,
     ``stun.voipstunt.com:3478`` and ``stun.xten.com:3478`` (this is the default).
 
-stunKeepaliveSeconds
+.. option:: options.stunKeepaliveSeconds
+
     Interval in seconds between contacting a STUN server to
     maintain NAT mapping. Default is ``24`` and you can set it to ``0`` to
     disable contacting STUN servers.
 
 .. _set-low-priority:
 
-setLowPriority
+.. option:: options.setLowPriority
+
     Syncthing will attempt to lower its process priority at startup.
     Specifically: on Linux, set itself to a separate process group, set the
     niceness level of that process group to nine and the I/O priority to
@@ -1036,12 +1137,14 @@ options.  These will be used when adding a new remote device or folder, either
 through the GUI or the command line interface.  The following child elements can
 be present in the ``defaults`` element:
 
-device
+.. option:: defaults.device
+
     Template for a ``device`` element, with the same internal structure.  Any
     fields here will be used for a newly added remote device.  The ``id``
     attribute is meaningless in this context.
 
-folder
+.. option:: defaults.folder
+
     Template for a ``folder`` element, with the same internal structure.  Any
     fields here will be used for a newly added shared folder.  The ``id``
     attribute is meaningless in this context.

--- a/users/config.rst
+++ b/users/config.rst
@@ -14,6 +14,7 @@ Synopsis
     $HOME/Library/Application Support/Syncthing
     %LOCALAPPDATA%\Syncthing
 
+
 Description
 -----------
 
@@ -62,6 +63,7 @@ The database contains the following files:
 :file:`index-{*}.db`
     A directory holding the database with metadata and hashes of the files
     currently on disk and available from peers.
+
 
 Config File Format
 ------------------
@@ -227,6 +229,7 @@ The following shows an example of a default configuration file (IDs will differ)
         </defaults>
     </configuration>
 
+
 Configuration Element
 ---------------------
 
@@ -257,6 +260,7 @@ this additional child element:
     Contains the ID of the device that should be ignored. Connection attempts
     from this device are logged to the console but never displayed in the web
     GUI.
+
 
 Folder Element
 --------------
@@ -562,6 +566,7 @@ The following child elements may exist:
     .. todo:: Describe element!
     .. bool                               follow_junctions           = 34 [(ext.goname) = "JunctionsAsDirs", (ext.xml) = "junctionsAsDirs", (ext.json) = "junctionsAsDirs"];
 
+
 Device Element
 --------------
 
@@ -747,6 +752,7 @@ From the following child elements at least one ``address`` child must exist.
     device then needs an encryption password set.  Refer to the detailed
     explanation under :doc:`untrusted`.
 
+
 GUI Element
 -----------
 
@@ -846,6 +852,7 @@ The following child elements may be present:
     ``ldap``
         LDAP authentication. Requires ldap top level config section to be present.
 
+
 LDAP Element
 ------------
 
@@ -894,6 +901,7 @@ described in detail under :doc:`ldap`.
 .. option:: ldap.searchFilter
 
     Search filter for user searches.
+
 
 Options Element
 ---------------
@@ -1234,6 +1242,7 @@ The ``options`` element contains all other global configuration options.
     Only for compatibility with old devices, as detailed in
     :doc:`/advanced/option-insecure-allow-old-tls-versions`.
 
+
 Defaults Element
 ----------------
 
@@ -1308,6 +1317,7 @@ be present in the ``defaults`` element:
 
     Even sharing with other remote devices can be done in the template by
     including the appropriate :opt:`folder.device` element underneath.
+
 
 .. _listen-addresses:
 

--- a/users/config.rst
+++ b/users/config.rst
@@ -302,8 +302,9 @@ describes one folder. The following attributes may be set on the ``folder``
 element:
 
 .. option:: folder.id
+    :mandatory:
 
-    The folder ID, which must be unique. (mandatory)
+    The folder ID, which must be unique.
 
 .. option:: folder.label
 
@@ -312,9 +313,10 @@ element:
     labels. (optional)
 
 .. option:: folder.path
+    :mandatory:
 
     The path to the directory where the folder is stored on this
-    device; not sent to other devices. (mandatory)
+    device; not sent to other devices.
 
 .. option:: folder.type
 
@@ -558,8 +560,9 @@ it is not present. The following attributes may be set on the ``device``
 element:
 
 .. option:: device.id
+    :mandatory:
 
-    The :ref:`device ID <device-ids>`. (mandatory)
+    The :ref:`device ID <device-ids>`.
 
 .. option:: device.name
 
@@ -607,6 +610,7 @@ element:
 From the following child elements at least one ``address`` child must exist.
 
 .. option:: device.address
+    :mandatory: At least one must be present.
 
     Contains an address or host name to use when attempting to connect to this device.
     Entries other than ``dynamic`` need a protocol specific prefix. For the TCP protocol
@@ -723,8 +727,9 @@ be set on the ``gui`` element:
 The following child elements may be present:
 
 .. option:: gui.address
+    :mandatory: Exactly one element must be present.
 
-    Set the listen address. Exactly one address element must be present. Allowed address formats are:
+    Set the listen address.  Allowed address formats are:
 
     IPv4 address and port (``127.0.0.1:8384``)
         The address and port are used as given.

--- a/users/config.rst
+++ b/users/config.rst
@@ -1152,23 +1152,16 @@ The ``options`` element contains all other global configuration options.
     ``stun.voiparound.com:3478``, ``stun.voipbuster.com:3478``,
     ``stun.voipstunt.com:3478`` and ``stun.xten.com:3478`` (this is the default).
 
-.. option:: options.stunKeepaliveSeconds
-
-    .. todo:: Replaced by :opt:`stunKeepaliveStartS` and :opt:`stunKeepaliveMinS`
-
-    Interval in seconds between contacting a STUN server to
-    maintain NAT mapping. Default is ``24`` and you can set it to ``0`` to
-    disable contacting STUN servers.
-
 .. option:: options.stunKeepaliveStartS
 
-    .. todo:: Describe element!
-    .. int32           stun_keepalive_start_s                   = 43 [(ext.default) = "180"];
+    Interval in seconds between contacting a STUN server to maintain NAT
+    mapping. Default is ``24`` and you can set it to ``0`` to disable contacting
+    STUN servers.  The interval is automatically reduced if needed, down to a
+    minimum of :opt:`stunKeepaliveMinS`.
 
 .. option:: options.stunKeepaliveMinS
 
-    .. todo:: Describe element!
-    .. int32           stun_keepalive_min_s                     = 44 [(ext.default) = "20"];
+    Minimum for the :opt:`stunKeepaliveStartS` interval, in seconds.
 
 .. option:: options.setLowPriority
 

--- a/users/config.rst
+++ b/users/config.rst
@@ -312,6 +312,12 @@ element:
     be different on each device, empty, and/or identical to other folder
     labels. (optional)
 
+.. option:: folder.filesystemType
+
+    .. todo:: Document available filesystem types.
+    .. FILESYSTEM_TYPE_BASIC
+    .. FILESYSTEM_TYPE_FAKE
+
 .. option:: folder.path
     :mandatory:
 
@@ -373,11 +379,15 @@ The following child elements may exist:
     Syncthing will currently add this automatically if it is not present in
     the configuration file.
 
+    .. todo:: Describe ``encryptionPassword`` sub-element!
+
 .. option:: folder.minDiskFree
 
-    The minimum required free space that should be available on the disk this folder
-    resides. The folder will be stopped when the value drops below the threshold. Accepted units are
-    ``%``, ``kB``, ``MB``, ``GB`` and ``TB``. Set to zero to disable.
+    The minimum required free space that should be available on the disk this
+    folder resides.  The folder will be stopped when the value drops below the
+    threshold.  The element content is interpreted according to the given
+    ``unit`` attribute.  Accepted ``unit`` values are ``%`` (percent of the disk
+    / volume size), ``kB``, ``MB``, ``GB`` and ``TB``.  Set to zero to disable.
 
 .. option:: folder.versioning
 
@@ -387,13 +397,17 @@ The following child elements may exist:
 	:doc:`versioning`
 
 .. option:: folder.copiers
-	    folder.pullers
 	    folder.hashers
 
-    The number of copier, puller and hasher routines to use, or ``0`` for the
+    The number of copier and hasher routines to use, or ``0`` for the
     system determined optimums. These are low level performance options for
     advanced users only; do not change unless requested to or you've actually
     read and understood the code yourself. :)
+
+.. option:: folder.pullerMaxPendingKiB
+
+    .. todo:: Describe element!
+    .. int32                              puller_max_pending_kib     = 15 [(ext.goname) = "PullerMaxPendingKiB", (ext.xml) = "pullerMaxPendingKiB", (ext.json) = "pullerMaxPendingKiB"];
 
 .. option:: folder.order
 
@@ -524,6 +538,16 @@ The following child elements may exist:
     filesystem supports it.
 
     See :ref:`folder-copyRangeMethod` for details.
+
+.. option:: folder.caseSensitiveFS
+
+    .. todo:: Describe element!
+    .. bool                               case_sensitive_fs          = 33 [(ext.goname) = "CaseSensitiveFS", (ext.xml) = "caseSensitiveFS", (ext.json) = "caseSensitiveFS"];
+
+.. option:: folder.junctionsAsDirs
+
+    .. todo:: Describe element!
+    .. bool                               follow_junctions           = 34 [(ext.goname) = "JunctionsAsDirs", (ext.xml) = "junctionsAsDirs", (ext.json) = "junctionsAsDirs"];
 
 Device Element
 --------------
@@ -664,6 +688,11 @@ From the following child elements at least one ``address`` child must exist.
     If given, this restricts connections to this device to only this network
     (see :ref:`allowed-networks`).
 
+.. option:: device.autoAcceptFolders
+
+    .. todo:: Describe element!
+    .. bool                    auto_accept_folders        = 11;
+
 .. option:: device.maxSendKbps
 
     Maximum send rate to use for this device. Unit is kibibytes/second, despite
@@ -693,6 +722,9 @@ From the following child elements at least one ``address`` child must exist.
     firewall settings need to be done manually and the link will probably not
     work for link-local IPv6 addresses because of modern browser limitations.
 
+.. option:: device.untrusted
+
+    .. todo:: Describe element!
 
 GUI Element
 -----------
@@ -767,6 +799,14 @@ The following child elements may be present:
     If true, this allows access to the web GUI from outside (i.e. not localhost)
     without authorization. A warning will displayed about this setting on startup.
 
+.. option:: gui.insecureSkipHostcheck
+
+    .. todo:: Describe element!
+
+.. option:: gui.insecureAllowFrameLoading
+
+    .. todo:: Describe element!
+
 .. option:: gui.theme
 
     The name of the theme to use.
@@ -819,6 +859,16 @@ The ``ldap`` element contains LDAP configuration options.
 .. option:: ldap.insecureSkipVerify
 
     Skip verification (``true`` or ``false``).
+
+.. option:: ldap.searchBaseDN
+
+    .. todo:: Describe element!
+    .. string        search_base_dn       = 5 [(ext.goname) = "SearchBaseDN", (ext.xml) = "searchBaseDN,omitempty", (ext.json) = "searchBaseDN"];
+
+.. option:: ldap.searchFilter
+
+    .. todo:: Describe element!
+    .. string        search_filter        = 6 [(ext.xml) = "searchFilter,omitempty"];
 
 Options Element
 ---------------
@@ -1022,9 +1072,11 @@ The ``options`` element contains all other global configuration options.
 
 .. option:: options.minHomeDiskFree
 
-    The minimum required free space that should be available on the
-    partition holding the configuration and index. Accepted units are ``%``, ``kB``,
-    ``MB``, ``GB`` and ``TB``.
+    The minimum required free space that should be available on the partition
+    holding the configuration and index.  The element content is interpreted
+    according to the given ``unit`` attribute.  Accepted ``unit`` values are
+    ``%`` (percent of the disk / volume size), ``kB``, ``MB``, ``GB`` and
+    ``TB``.  Set to zero to disable.
 
 .. option:: options.releasesURL
 
@@ -1068,10 +1120,21 @@ The ``options`` element contains all other global configuration options.
 
 .. option:: options.stunKeepaliveSeconds
 
+    .. todo:: Replaced by :opt:`stunKeepaliveStartS` and :opt:`stunKeepaliveMinS`
+
     Interval in seconds between contacting a STUN server to
     maintain NAT mapping. Default is ``24`` and you can set it to ``0`` to
     disable contacting STUN servers.
 
+.. option:: options.stunKeepaliveStartS
+
+    .. todo:: Describe element!
+    .. int32           stun_keepalive_start_s                   = 43 [(ext.default) = "180"];
+
+.. option:: options.stunKeepaliveMinS
+
+    .. todo:: Describe element!
+    .. int32           stun_keepalive_min_s                     = 44 [(ext.default) = "20"];
 
 .. option:: options.setLowPriority
 
@@ -1082,6 +1145,60 @@ The ``options`` element contains all other global configuration options.
     to nine; on Windows, set the process priority class to below normal. To
     disable this behavior, for example to control process priority yourself
     as part of launching Syncthing, set this option to ``false``.
+
+.. option:: options.crashReportingURL
+
+    .. todo:: Describe element!
+    .. string          crash_reporting_url                      = 41 [(ext.goname) = "CRURL", (ext.xml) = "crashReportingURL", (ext.json) = "crURL", (ext.default) = "https://crash.syncthing.net/newcrash"];
+
+.. option:: options.crashReportingEnabled
+
+    .. todo:: Describe element!
+    .. bool            crash_reporting_enabled                  = 42 [(ext.goname) = "CREnabled", (ext.default) = "true"];
+
+.. option:: options.databaseTuning
+
+    .. todo:: Describe element!
+    .. Tuning          database_tuning                          = 46 [(ext.restart) = true];
+    .. TUNING_AUTO  = 0;
+    .. TUNING_SMALL = 1;
+    .. TUNING_LARGE = 2;
+
+.. option:: options.maxConcurrentIncomingRequestKiB
+
+    .. todo:: Describe element!
+    .. int32           max_concurrent_incoming_request_kib      = 47 [(ext.goname) = "RawMaxCIRequestKiB", (ext.xml) = "maxConcurrentIncomingRequestKiB", (ext.json) = "maxConcurrentIncomingRequestKiB"];
+
+.. option:: options.announceLANAddresses
+
+    .. todo:: Describe element!
+    .. bool            announce_lan_addresses                   = 48 [(ext.goname)= "AnnounceLANAddresses", (ext.xml) = "announceLANAddresses", (ext.json) = "announceLANAddresses", (ext.default) = "true"];
+
+.. option:: options.sendFullIndexOnUpgrade
+
+    .. todo:: Describe element!
+    .. bool            send_full_index_on_upgrade               = 49;
+
+.. option:: options.featureFlag
+
+    .. todo:: Describe element!
+    .. repeated string feature_flags                            = 50;
+
+.. option:: options.connectionLimitEnough
+
+    The number of connections at which we stop trying to connect to more
+    devices, zero meaning no limit. Does not affect incoming connections.
+
+.. option:: options.connectionLimitMax
+
+    The maximum number of connections which we will allow in total, zero meaning
+    no limit. Affects incoming connections and prevents attempting outgoing
+    connections.
+
+.. option:: options.insecureAllowOldTLSVersions
+
+    .. todo:: Describe element!
+    .. bool insecure_allow_old_tls_versions = 53 [(ext.goname)= "InsecureAllowOldTLSVersions", (ext.xml) = "insecureAllowOldTLSVersions", (ext.json) = "insecureAllowOldTLSVersions"];
 
 Defaults Element
 ----------------

--- a/users/config.rst
+++ b/users/config.rst
@@ -1188,8 +1188,8 @@ The ``options`` element contains all other global configuration options.
 .. option:: options.crashReportingEnabled
 
     Switch to opt out from the :doc:`automatic crash reporting <crashrep>`
-    feature to avoid Syncthing "phoning home" on serious troubles.  Defaults to
-    ``true``, to help the developers troubleshoot.
+    feature. Set ``false`` to keep Syncthing from sending panic logs on serious
+    troubles.  Defaults to ``true``, to help the developers troubleshoot.
 
 .. option:: options.databaseTuning
 

--- a/users/faq-parts/general.rst
+++ b/users/faq-parts/general.rst
@@ -38,8 +38,9 @@ The following are *not* synchronized;
 -  File or directory owners and Groups (not preserved)
 -  Directory modification times (not preserved)
 -  Hard links (followed, not preserved)
--  Windows junctions (synced as ordinary directories; require enabling
-   in the configuration on a per-folder basis)
+-  Windows junctions (synced as ordinary directories; require enabling in
+   :stconf:opt:`the configuration <folder.junctionsAsDirs>` on a per-folder
+   basis)
 -  Extended attributes, resource forks (not preserved)
 -  Windows, POSIX or NFS ACLs (not preserved)
 -  Devices, FIFOs, and other specials (ignored)

--- a/users/faq-parts/troubleshooting.rst
+++ b/users/faq-parts/troubleshooting.rst
@@ -86,15 +86,15 @@ This protects against most forms of `DNS rebinding attack
 <https://en.wikipedia.org/wiki/DNS_rebinding>`__ against the GUI.
 
 To pass this test, ensure that you are accessing the GUI using an URL that
-begins with `http://localhost`, `http://127.0.0.1` or `http://[::1]`. HTTPS
+begins with ``http://localhost``, ``http://127.0.0.1`` or ``http://[::1]``. HTTPS
 is fine too, of course.
 
 If you are using a proxy in front of Syncthing you may need to disable this
 check, after ensuring that the proxy provides sufficient authentication to
 protect against unauthorized access. Either:
 
-- Make sure the proxy sets a `Host` header containing `localhost`, or
-- Set `insecureSkipHostcheck` in the advanced settings, or
+- Make sure the proxy sets a ``Host`` header containing ``localhost``, or
+- Set :stconf:opt:`gui.insecureSkipHostcheck` in the advanced settings, or
 - Bind the GUI/API to a non-localhost listen port.
 
 In all cases, username/password authentication and HTTPS should be used.

--- a/users/faq-parts/troubleshooting.rst
+++ b/users/faq-parts/troubleshooting.rst
@@ -58,8 +58,8 @@ causes a certain amount of extra CPU usage to calculate the summary data it
 presents. Note however that once things are *in sync* CPU usage should be
 negligible.
 
-To minimize the impact of this, Syncthing attempts to :ref:`lower the
-process priority <set-low-priority>` when starting up.
+To minimize the impact of this, Syncthing attempts to :stconf:opt:`lower the
+process priority <setLowPriority>` when starting up.
 
 To further limit the amount of CPU used when syncing and scanning, set the
 environment variable ``GOMAXPROCS`` to the maximum number of CPU cores

--- a/users/introducer.rst
+++ b/users/introducer.rst
@@ -1,5 +1,3 @@
-.. _introducer:
-
 Introducer Configuration
 ========================
 

--- a/users/syncing.rst
+++ b/users/syncing.rst
@@ -52,7 +52,7 @@ parts of a file have changed without reading the file and computing new SHA256
 hashes for each block.
 
 The watcher does not immediately schedule a scan when a change is detected. It
-accumulates changes for 10s (adjustable by :ref:`fsWatcherDelayS <fsWatcherDelayS>`) and deleted files
+accumulates changes for 10s (adjustable by :stconf:opt:`fsWatcherDelayS`) and deleted files
 are further delayed for 1min. Therefore it is expected that you experience a
 slight delay between making the change and it appearing on another device.
 

--- a/users/untrusted.rst
+++ b/users/untrusted.rst
@@ -128,7 +128,8 @@ untrusted and will get encrypted folder data, using different passwords.
         </device>
     </folder>
 
-On untrusted devices the type of the folders has to be ``receiveencrypted``.
+On untrusted devices the :stconf:opt:`type of the folders <folder.type>` has to
+be ``receiveencrypted``.
 
 Caveats
 -------

--- a/users/versioning.rst
+++ b/users/versioning.rst
@@ -1,5 +1,3 @@
-.. _versioning:
-
 File Versioning
 ===============
 

--- a/users/versioning.rst
+++ b/users/versioning.rst
@@ -14,6 +14,15 @@ defaults to "no file versioning", i.e. no old copies of files are kept.
     Bob. If Alice changes a file locally on her own computer Syncthing will
     not and can not archive the old version.
 
+.. .. stconf:option:: folder.versioning
+
+    .. todo:: Describe element attributes!
+    .. string              type               = 1[(ext.xml) = "type,attr"];
+    .. map<string, string> parameters         = 2 [(ext.goname) = "Params", (ext.json) = "params"];
+    .. int32               cleanup_interval_s = 3 [(ext.default) = "3600"];
+    .. string              fs_path            = 4 [(ext.goname) = "FSPath"];
+    .. fs.FilesystemType   fs_type            = 5 [(ext.goname) = "FSType"];
+
 Trash Can File Versioning
 -------------------------
 


### PR DESCRIPTION
This is effectively a rewrite of #610 by @tomasz1986.  A completely different approach though, which uses the formal mechanisms of Sphinx through a custom plugin implementing an additional "directive" and "role" in RST parlor.  This gives us high quality permanent links to individual config options, even with highlighting on the link target anchor (option name).  All this without having to repeat oneself in the RST documents, as with the old approach where each option needed a separate label with a hopefully matching name.  And it works easily for cross-referencing any option internally from other documents.

For example, in the RST document:

```
.. stconf:option:: folder.fsWatcherDelayS

    Blah blah, only relevant if :stconf:opt:`fsWatcherDelayEnabled` is on.
```

This gives us an external link target (when deployed) https://docs.syncthing.net/users/config.html#config-option-folder.fswatcherdelays.  The internal references work as shown in the RST example.

This is based on the commits of #709 because, well I work things as they come along :-)  It also adds all (?) missing configuration options I could find in the protobuf definitions.  **Please help getting those documented where possible**, so we don't leave lots of TODOs behind after this PR!

**Reviewing is best done each commit by itself.** They include logically separate changes and have some more explanations in the commit messages.