### PR TITLE
users/ignoring: Add note with example about backslash in Windows

### DIFF
--- a/users/ignoring.rst
+++ b/users/ignoring.rst
@@ -59,8 +59,15 @@ The ``.stignore`` file contains a list of file or path patterns. The
 
 -  **Backslash** (``\``) "escapes" a special character so that it loses its
    special meaning. For example, ``\{banana\}`` matches ``{banana}`` exactly
-   and does not denote a set of alternatives as above. *Escaped characters
-   are not supported on Windows.*
+   and does not denote a set of alternatives as above.
+
+.. note::
+
+Escaped characters are not supported on Windows, where ``\`` is the path
+separator. If you still need to match files that have square or curly
+brackets in their names, one possible workaround is to replace them with
+``?``, which will then match any character. For example, you can type
+``?banana?`` to match both ``[banana]`` and ``{banana}``, and so on.
 
 -  A pattern beginning with ``/`` matches in the root of the folder only.
    ``/foo`` matches ``foo`` but not ``subdir/foo``.

--- a/users/ignoring.rst
+++ b/users/ignoring.rst
@@ -63,11 +63,12 @@ The ``.stignore`` file contains a list of file or path patterns. The
 
 .. note::
 
-Escaped characters are not supported on Windows, where ``\`` is the path
-separator. If you still need to match files that have square or curly
-brackets in their names, one possible workaround is to replace them with
-``?``, which will then match any character. For example, you can type
-``?banana?`` to match both ``[banana]`` and ``{banana}``, and so on.
+   Escaped characters are not supported on Windows, where ``\`` is the
+   path separator. If you still need to match files that have square or
+   curly brackets in their names, one possible workaround is to replace
+   them with ``?``, which will then match any character. For example,
+   you can type ``?banana?`` to match both ``[banana]`` and
+   ``{banana}``, and so on.
 
 -  A pattern beginning with ``/`` matches in the root of the folder only.
    ``/foo`` matches ``foo`` but not ``subdir/foo``.


### PR DESCRIPTION
Replace the brief comment about escaped characters being unsupported in
Windows with a longer note that actually explains what backslash is used
for in the OS. Also, add a possible workaround showing how to overcome
the limitation.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>