### PR TITLE
users/faq: Update info on syncing Windows junctions

### DIFF
--- a/users/faq-parts/general.rst
+++ b/users/faq-parts/general.rst
@@ -37,7 +37,9 @@ The following are *not* synchronized;
 
 -  File or directory owners and Groups (not preserved)
 -  Directory modification times (not preserved)
--  Hard links and Windows directory junctions (followed, not preserved)
+-  Hard links (followed, not preserved)
+-  Windows junctions (synced as ordinary directories; require enabling
+   in the configuration on a per-folder basis)
 -  Extended attributes, resource forks (not preserved)
 -  Windows, POSIX or NFS ACLs (not preserved)
 -  Devices, FIFOs, and other specials (ignored)


### PR DESCRIPTION
users/faq: Update info on syncing Windows junctions

Separate hard links and Windows junctions, adding more detailed
information on the latter, also mentioning the requirement to enable
their synchronisation on a per-folder basis.

Ref: https://github.com/syncthing/syncthing/commit/ee445e35a0547ccfa7d239ff558819db9ea94348

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>