### PR TITLE
users/contrib: Update curl for Windows system requirements

### DIFF
--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -74,7 +74,7 @@ Cross-platform
 
     $ curl -sS https://webinstall.dev/syncthing | bash
 
-  Windows 10 ::
+  Windows 10 (build 1803) or later ::
 
     > curl.exe -A MS https://webinstall.dev/syncthing | powershell
 


### PR DESCRIPTION
Add specific build number for Windows 10 that had the curl.exe binary
built into it, and also indicate that later versions of Windows (such
as Windows 11) also support it.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>