### PR TITLE
Add version picker box at the top

### DIFF
--- a/_static/version_redirect.js
+++ b/_static/version_redirect.js
@@ -51,18 +51,22 @@ function stripVersionPath(path, versions) {
     return path;
 }
 
-function redirectToPath(newPath) {
+function redirectToPath(newPath, keepHistory) {
     const fragment = window.location.href.indexOf('#');
     if (fragment != -1) {
         newPath += window.location.href.slice(fragment);
     }
 
     if (newPath && newPath != window.location.pathname) {
-        window.location.replace(newPath);
+        if (keepHistory) {
+            window.location.assign(newPath);
+        } else {
+            window.location.replace(newPath);
+        }
     }
 }
 
-function redirectToVersion(target, available) {
+function redirectToVersion(target, available, keepHistory) {
     const tail = stripVersionPath(window.location.pathname, available + [target]);
 
     var newPath = '';
@@ -72,7 +76,7 @@ function redirectToVersion(target, available) {
     if (tail) {
         newPath += tail;
     }
-    redirectToPath(newPath);
+    redirectToPath(newPath, keepHistory);
 }
 
 function setVersionPickerOptions() {
@@ -99,7 +103,7 @@ function setVersionPickerOptions() {
 function pickVersion() {
     getVersions.then(function (available) {
         const targetVersion = document.getElementById('version-picker').value;
-        redirectToVersion(targetVersion, available);
+        redirectToVersion(targetVersion, available, true);
     });
 }
 
@@ -111,7 +115,7 @@ const versionParam = urlParams.get('version');
 if (versionParam) {
     getVersions.then(function (available) {
         const useVersion = findBestVersion(versionParam, available);
-        redirectToVersion(useVersion, available);
+        redirectToVersion(useVersion, available, false);
     });
 }
 

--- a/_static/version_redirect.js
+++ b/_static/version_redirect.js
@@ -1,5 +1,6 @@
 var collator = new Intl.Collator(undefined, {numeric: true, sensitivity: 'base'});
 
+// Override MIME type to avoid "invalid XML" warnings when using $.getJSON()
 $.ajaxSetup({beforeSend: function (xhr) {
     if (xhr.overrideMimeType) {
         xhr.overrideMimeType("application/json");
@@ -41,11 +42,14 @@ function findBestVersion(version, available) {
     return bestVersion;
 }
 
-function stripVersionPath(path, versions) {
+function splitVersionPath(path, versions) {
+    // Find end of first path component, disregarding leading slash
     var slash = path.indexOf('/', 1);
     if (slash != -1) {
-        if (versions.indexOf(path.slice(1, slash)) != -1) {
-            return [path.slice(1, slash), path.slice(slash)];
+        var firstComponent = path.slice(1, slash);
+        if (versions.indexOf(firstComponent) != -1) {
+            // Component is a valid known version path, split it off
+            return [firstComponent, path.slice(slash)];
         }
     }
     return ['', path];
@@ -67,7 +71,7 @@ function redirectToPath(newPath, keepHistory) {
 }
 
 function redirectToVersion(target, available, keepHistory) {
-    const tail = stripVersionPath(window.location.pathname, available + [target])[1];
+    const tail = splitVersionPath(window.location.pathname, available + [target])[1];
 
     var newPath = '';
     if (target) {
@@ -84,7 +88,7 @@ function setVersionPickerOptions() {
         var items = [
             '<option value="">latest</option>'
         ];
-        var current = stripVersionPath(window.location.pathname, available)[0];
+        var current = splitVersionPath(window.location.pathname, available)[0];
         $.each(available, function (key, val) {
             var item = '<option value="' + val + '"';
             if (val == current) item += ' selected';

--- a/_static/version_redirect.js
+++ b/_static/version_redirect.js
@@ -69,6 +69,34 @@ function redirectToVersion(target, available) {
     redirectToPath(newPath);
 }
 
+function setVersionPickerOptions() {
+    getVersions.then(function (available) {
+        var items = [
+            '<option value="">latest</option>'
+        ];
+        $.each(available, function (key, val) {
+            items.push('<option value="' + val + '">' + val + '</option>');
+        });
+        let sel = document.createElement('select');
+        sel.setAttribute('id', 'version-picker');
+        sel.onchange = pickVersion;
+        sel.innerHTML = items.join('');
+        let note = document.createElement('div');
+        note.classList.add('admonition', 'note');
+        note.append('Browsing documentation for version: ');
+        note.append(sel);
+        var doc = document.getElementsByClassName('document')[0];
+        doc.prepend(note);
+    });
+}
+
+function pickVersion() {
+    getVersions.then(function (available) {
+        const targetVersion = document.getElementById('version-picker').value;
+        redirectToVersion(targetVersion, available);
+    });
+}
+
 
 const urlParams = new URLSearchParams(window.location.search);
 const versionParam = urlParams.get('version');
@@ -80,3 +108,5 @@ if (versionParam) {
         redirectToVersion(useVersion, available);
     });
 }
+
+window.addEventListener('DOMContentLoaded', setVersionPickerOptions);

--- a/_static/version_redirect.js
+++ b/_static/version_redirect.js
@@ -1,5 +1,11 @@
 var collator = new Intl.Collator(undefined, {numeric: true, sensitivity: 'base'});
 
+$.ajaxSetup({beforeSend: function (xhr) {
+    if (xhr.overrideMimeType) {
+        xhr.overrideMimeType("application/json");
+    }
+}});
+
 const VERSIONS_LIST = "/versions.json";
 
 const getVersions = $.getJSON(VERSIONS_LIST).then(function (data) {

--- a/_static/version_redirect.js
+++ b/_static/version_redirect.js
@@ -89,6 +89,7 @@ function setVersionPickerOptions() {
         });
         let sel = document.createElement('select');
         sel.setAttribute('id', 'version-picker');
+        sel.setAttribute('style', 'font: inherit;');
         sel.onchange = pickVersion;
         sel.innerHTML = items.join('');
         let note = document.createElement('div');

--- a/_static/version_redirect.js
+++ b/_static/version_redirect.js
@@ -45,10 +45,10 @@ function stripVersionPath(path, versions) {
     var slash = path.indexOf('/', 1);
     if (slash != -1) {
         if (versions.indexOf(path.slice(1, slash)) != -1) {
-            path = path.slice(slash);
+            return [path.slice(1, slash), path.slice(slash)];
         }
     }
-    return path;
+    return ['', path];
 }
 
 function redirectToPath(newPath, keepHistory) {
@@ -67,7 +67,7 @@ function redirectToPath(newPath, keepHistory) {
 }
 
 function redirectToVersion(target, available, keepHistory) {
-    const tail = stripVersionPath(window.location.pathname, available + [target]);
+    const tail = stripVersionPath(window.location.pathname, available + [target])[1];
 
     var newPath = '';
     if (target) {
@@ -84,8 +84,12 @@ function setVersionPickerOptions() {
         var items = [
             '<option value="">latest</option>'
         ];
+        var current = stripVersionPath(window.location.pathname, available)[0];
         $.each(available, function (key, val) {
-            items.push('<option value="' + val + '">' + val + '</option>');
+            var item = '<option value="' + val + '"';
+            if (val == current) item += ' selected';
+            item += '>' + val + '</option>';
+            items.push(item);
         });
         let sel = document.createElement('select');
         sel.setAttribute('id', 'version-picker');

--- a/_static/version_redirect.js
+++ b/_static/version_redirect.js
@@ -97,7 +97,7 @@ function setVersionPickerOptions() {
         sel.onchange = pickVersion;
         sel.innerHTML = items.join('');
         let note = document.createElement('div');
-        note.classList.add('admonition', 'note');
+        note.classList.add('admonition', 'hint');
         note.append('Browsing documentation for version: ');
         note.append(sel);
         var doc = document.getElementsByClassName('document')[0];

--- a/netlify-build.sh
+++ b/netlify-build.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Download pre-rendered / old versions of docs.
 mkdir -p _build
-git clone --depth 1 -b inject-version-picker https://github.com/acolomb/syncthing-docs-pre-rendered.git _build/html
+git clone --depth 1 https://github.com/syncthing/docs-pre-rendered.git _build/html
 rm -rf _build/html/.git
 go run _script/lsver.go _build/html > _build/html/versions.json
 

--- a/netlify-build.sh
+++ b/netlify-build.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Download pre-rendered / old versions of docs.
 mkdir -p _build
-git clone --depth 1 -b rebuild-all-version-history https://github.com/acolomb/syncthing-docs-pre-rendered.git _build/html
+git clone --depth 1 -b rebuild-all-version-history  https://github.com/acolomb/syncthing-docs-pre-rendered.git _build/html
 rm -rf _build/html/.git
 go run _script/lsver.go _build/html > _build/html/versions.json
 

--- a/netlify-build.sh
+++ b/netlify-build.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Download pre-rendered / old versions of docs.
 mkdir -p _build
-git clone https://github.com/syncthing/docs-pre-rendered.git _build/html
+git clone --depth 1 -b rebuild-all-version-history https://github.com/acolomb/syncthing-docs-pre-rendered.git _build/html
 rm -rf _build/html/.git
 go run _script/lsver.go _build/html > _build/html/versions.json
 

--- a/netlify-build.sh
+++ b/netlify-build.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Download pre-rendered / old versions of docs.
 mkdir -p _build
-git clone --depth 1 -b rebuild-all-version-history  https://github.com/acolomb/syncthing-docs-pre-rendered.git _build/html
+git clone --depth 1 -b inject-version-picker https://github.com/acolomb/syncthing-docs-pre-rendered.git _build/html
 rm -rf _build/html/.git
 go run _script/lsver.go _build/html > _build/html/versions.json
 


### PR DESCRIPTION
Add a header note allowing to pick a specific version.  It is populated from the `versions.json` file and redirects to the specified version when changed.

![Screenshot 2022-01-23 at 15-33-41 Welcome to Syncthing’s documentation — Syncthing v1 documentation](https://user-images.githubusercontent.com/6996887/150683605-d58c110f-6129-49cc-a468-a679b8888047.png)

To-Do
-----

* [x] Preset the current version in the picker
* [x] When merged, replicate this into all the historic versions at https://github.com/syncthing/docs-pre-rendered