### PR TITLE
Build fixes and cleanup for Sphinx version 4

### DIFF
--- a/dev/building.rst
+++ b/dev/building.rst
@@ -11,7 +11,7 @@ Building Syncthing
 
 .. note::
     Syncthing uses Go modules, which is a fairly new development in the Go
-    ecosystem. You can find more information about modules `here <https://blog.golang.org/using-go-modules>`__.
+    ecosystem. You can find more information about modules `here <https://go.dev/blog/using-go-modules>`__.
     If you are not a seasoned Go developer you can just go with the flow as this is the new thing.
 
 Branches and Tags
@@ -32,7 +32,7 @@ Prerequisites
    always using the latest stable version. At the time of writing this is **Go 1.17**.
 -  Git
 -  If you want to build Debian packages FPM is required. See FPM's
-   `installation information <https://fpm.readthedocs.io/en/latest/installing.html>`__.
+   `installation information <https://fpm.readthedocs.io/en/latest/installation.html>`__.
 -  To build Windows executables, installing `goversioninfo
    <https://github.com/josephspurrier/goversioninfo>`__ is recommended
    in order to add file properties and icon to the compiled binaries.
@@ -40,7 +40,7 @@ Prerequisites
 
 If you're not already a Go developer, the easiest way to get going
 is to download the latest version of Go as instructed in
-https://golang.org/doc/install.
+https://go.dev/doc/install.
 
 .. note::
         Because Syncthing uses Go modules you do not need to set or care about "GOPATH".

--- a/dev/contributing.rst
+++ b/dev/contributing.rst
@@ -59,7 +59,7 @@ Trivial:
   A small change or refactor that is obviously correct. These may be pushed
   without review by any member of the core team. Examples:
   `removing dead code <https://github.com/syncthing/syncthing/commits/main>`__,
-  `updating values <https://github.com/syncthing/syncthing/commit/2aa028facb7ccbe48e85c8c444501cc3fb38ef24>`__.
+  :commit:`updating values <2aa028facb7ccbe48e85c8c444501cc3fb38ef24>`.
 
 Minor:
   A new feature, bugfix or refactoring that may need extra eyes on it to weed

--- a/dev/contributing.rst
+++ b/dev/contributing.rst
@@ -96,7 +96,7 @@ Go Specific
 ~~~~~~~~~~~
 
 - Follow the conventions laid out in `Effective
-  Go <https://golang.org/doc/effective_go.html>`__ as much as makes
+  Go <https://go.dev/doc/effective_go>`__ as much as makes
   sense. The review guidelines in `Go Code Review Comments
   <https://github.com/golang/go/wiki/CodeReviewComments>`__ should generally
   be followed.

--- a/dev/infrastructure.rst
+++ b/dev/infrastructure.rst
@@ -44,7 +44,7 @@ Relay Pool Server
 Runs the `strelaypoolsrv <https://github.com/syncthing/syncthing/tree/main/cmd/strelaypoolsrv>`__
 daemon to handle dynamic registration and announcement of relays.
 
-- `relays.syncthing.net <http://relays.syncthing.net>`__
+- `relays.syncthing.net <https://relays.syncthing.net>`__
 
 Relay Servers
 -------------
@@ -82,6 +82,6 @@ Monitoring
 
 The infrastructure is monitored and its status is publicly accessible on the following urls:
 
-- `status.syncthing.net <http://status.syncthing.net>`__ (Apex Ping)
+- `status.syncthing.net <https://status.syncthing.net>`__ (Apex Ping)
 - `monitor.syncthing.net <https://monitor.syncthing.net>`__ (Grafana)
 

--- a/dev/intro.rst
+++ b/dev/intro.rst
@@ -24,7 +24,7 @@ Contributing to the Syncthing Core
 ----------------------------------
 
 First of all, follow :ref:`building` to get your workspace set up correctly.
-Syncthing is written mainly in `Go <https://golang.org>`__ which has some
+Syncthing is written mainly in `Go <https://go.dev>`__ which has some
 fairly specific opinions on the required directory layout. If you're new to
 Go, don't fear -- it's a small language and easy to learn. There's a `wealth
 of resources <https://dave.cheney.net/resources-for-new-go-programmers>`__ on

--- a/dev/release-signing.rst
+++ b/dev/release-signing.rst
@@ -31,7 +31,7 @@ of the binary, computed at the time the release was made and signed by the
 Syncthing Release Management private key. The keys and signature are PEM
 encoded for ease of transmission - the details of the signature and encoding
 handling are in `the signature package
-<https://godoc.org/github.com/syncthing/syncthing/lib/signature>`__ The public
+<https://pkg.go.dev/github.com/syncthing/syncthing/lib/signature>`__ The public
 key is included in the source code and compiled into Syncthing.
 
 When Syncthing performs an automatic upgrade, it verifies the included

--- a/index.rst
+++ b/index.rst
@@ -56,5 +56,5 @@ We thank all the documentation contributors for their hard work:
 .. _GitHub: https://github.com/syncthing/docs
 .. _`issue tracker`: https://github.com/syncthing/syncthing/issues
 .. _`latest version`: https://github.com/syncthing/syncthing/releases/latest
-.. _`Security page`: https://syncthing.net/security.html
+.. _`Security page`: https://syncthing.net/security
 .. _`friendly forum`: https://forum.syncthing.net

--- a/netlify-build.sh
+++ b/netlify-build.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Download pre-rendered / old versions of docs.
 mkdir -p _build
-git clone https://github.com/syncthing/docs-pre-rendered.git _build/html
+git clone --depth 1 https://github.com/syncthing/docs-pre-rendered.git _build/html
 rm -rf _build/html/.git
 go run _script/lsver.go _build/html > _build/html/versions.json
 

--- a/rest/system-browse-get.rst
+++ b/rest/system-browse-get.rst
@@ -3,7 +3,7 @@ GET /rest/system/browse
 
 Returns a list of directories matching the path given by the optional parameter
 ``current``. The path can use `patterns as described in Go's filepath package
-<https://golang.org/pkg/path/filepath/#Match>`_. A '*' will always be appended
+<https://pkg.go.dev/path/filepath#Match>`_. A '*' will always be appended
 to the given path (e.g. ``/tmp/`` matches all its subdirectories). If the option
 ``current`` is not given, filesystem root paths are returned.
 

--- a/specs/bep-v1.rst
+++ b/specs/bep-v1.rst
@@ -22,7 +22,7 @@ for the last block which may be smaller.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
 "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
-document are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
+document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
 
 Transport and Authentication
 ----------------------------
@@ -135,7 +135,7 @@ values SHOULD  be simple strings identifying the implementation name, as a
 user would expect to see it, and the version string in the same manner. An
 example client name is "syncthing" and an example client version is "v0.7.2".
 The client version field SHOULD follow the patterns laid out in the `Semantic
-Versioning <http://semver.org/>`__ standard.
+Versioning <https://semver.org/>`__ standard.
 
 Immediately after exchanging Hello messages, the connection MUST be dropped
 if the remote device does not pass authentication.

--- a/users/autostart.rst
+++ b/users/autostart.rst
@@ -435,7 +435,7 @@ Permissions
 
 If you enabled the ``Ignore Permissions`` option in the Syncthing client's
 folder settings, then you will also need to add the line ``UMask=0002`` (or any
-other `umask setting <http://www.tech-faq.com/umask.html>`_ you like) in the
+other `umask setting <https://www.tech-faq.com/umask.html>`_ you like) in the
 ``[Service]`` section of the ``syncthing@.service`` file.
 
 Debugging

--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -97,7 +97,7 @@ Unofficial `RPM repo of Syncthing <https://copr.fedorainfracloud.org/coprs/dafta
 ArchLinux
 ~~~~~~~~~
 
-- Official Community Repository: `syncthing <https://www.archlinux.org/packages/?name=syncthing>`__
+- Official Community Repository: `syncthing <https://archlinux.org/packages/?name=syncthing>`__
 
 - Arch User Repository: `syncthing-discosrv <https://aur.archlinux.org/packages/syncthing-discosrv>`__ and `syncthingtray <https://aur.archlinux.org/packages/syncthingtray>`__
 
@@ -121,7 +121,7 @@ Docker
   Configurable image for the Raspberry Pi.
 
 - `Syncthing for Home Assistant OS <https://github.com/Poeschl/Hassio-Addons/tree/master/syncthing>`_
-  A docker based addon for `Home Assistant Operating System <https://www.home-assistant.io/installation/#compare-installation-methods/>`_
+  A docker based addon for `Home Assistant Operating System <https://www.home-assistant.io/installation/#compare-installation-methods>`_
 
 Gentoo
 ~~~~~~
@@ -136,7 +136,7 @@ FreshPorts: `syncthing <https://www.freshports.org/net/syncthing>`__
 macOS
 ~~~~~
 
-MacPorts: `syncthing <https://ports.macports.org/port/syncthing/summary>`__ ::
+MacPorts: `syncthing <https://ports.macports.org/port/syncthing/>`__ ::
 
     $ sudo port install syncthing
 
@@ -172,23 +172,23 @@ Package) available for ALL models x86, x86\_64, Arm (all including new models).
 RockStor
 ~~~~~~~~
 
-`Docker container <http://rockstor.com/docs/docker-based-rock-ons/syncthing.html>`_ and `registry entry <https://github.com/rockstor/rockon-registry/blob/master/syncthing.json>`_
+`Docker container <https://rockstor.com/docs/docker-based-rock-ons/syncthing.html>`_ and `registry entry <https://github.com/rockstor/rockon-registry/blob/master/syncthing.json>`_
 
 ClearOS / WikiSuite
 ~~~~~~~~~~~~~~~~~~~~
 
-Syncthing is part of `WikiSuite <http://wikisuite.org/>`_, and thus packaged for `ClearOS <http://wikisuite.org/How-to-install-Syncthing-on-ClearOS>`_.
+Syncthing is part of `WikiSuite <https://wikisuite.org/>`_, and thus packaged for `ClearOS <https://wikisuite.org/How-to-install-Syncthing-on-ClearOS>`_.
 
 Cloudron
 ~~~~~~~~
 
-Syncthing is available as a 1-click install on `Cloudron <https://cloudron.io>`_. For those unaware,
+Syncthing is available as a 1-click install on `Cloudron <https://www.cloudron.io>`_. For those unaware,
 Cloudron makes it easy to run apps on your server and keep them up-to-date and secure.
 
-.. image:: https://cloudron.io/img/button.svg
-   :target: https://cloudron.io/button.html?app=net.syncthing.cloudronapp2
+.. image:: https://www.cloudron.io/img/button.svg
+   :target: https://www.cloudron.io/button.html?app=net.syncthing.cloudronapp2
 
-There is a `demo available <https://my-demo.cloudron.me>`_ (username: cloudron password: cloudron)
+There is a `demo available <https://my.demo.cloudron.io>`_ (username: cloudron password: cloudron)
 
 The Cloudron package is developed `here <https://git.cloudron.io/cloudron/syncthing-app>`_.
 
@@ -203,13 +203,13 @@ Integrations
 REST API Bindings
 ~~~~~~~~~~~~~~~~~
 
-- Python: https://github.com/blakev/python-syncthing (https://pypi.python.org/pypi/syncthing)
+- Python: https://github.com/blakev/python-syncthing (https://pypi.org/project/syncthing/)
 - PHP: https://github.com/terzinnorbert/syncthing-rest
 
 Ports
 ~~~~~
 
-- Swift: `pulse-swift <https://source.ind.ie/project/pulse-swift/tree/master>`_
+- Swift: `pulse-swift <https://source.small-tech.org/project/pulse-swift/tree/master>`_
 
   Currently still in development and is "not yet usable by any standard". Only the Block Exchange Protocol layer and the Connection layer are completed.
 
@@ -255,14 +255,12 @@ Older, Possibly Unmaintained
 -  https://github.com/sieren/QSyncthingTray
 -  https://github.com/akissa/pysyncthing
 -  https://github.com/retgoat/syncthing-ruby
--  https://github.com/sodacode/Windows-Syncthing-Installer
+-  https://github.com/codabrink/Windows-Syncthing-Installer
 -  https://github.com/gutenye/syncthing-kindle
 -  https://github.com/m0ppers/syncthing-bar (OSX 10.10 only)
 -  https://github.com/graboluk/stiko
--  https://github.com/ALinuxNinja/salt-syncthing
 -  https://www.asustor.com/apps/app_detail?id=552
--  https://susestudio.com/a/qkdvwb/syncthing
--  https://source.ind.ie/project/pulse-swift/tree/master
+-  https://source.small-tech.org/project/pulse-swift/tree/master
 -  https://github.com/icaruseffect/syncthing-ubuntu-indicator
 -  https://github.com/bloones/SyncThingWin
 -  https://github.com/thunderbirdtr/syncthing_rpm
@@ -270,5 +268,5 @@ Older, Possibly Unmaintained
 -  https://github.com/cebe/pulse-php-discover
 -  https://github.com/sebw/bitbar-plugins
 -  https://github.com/nhojb/SyncthingBar
--  https://github.com/iss0/SyncthingTray
+-  https://github.com/jastBytes/SyncthingTray
 -  https://github.com/alex2108/syncthing-tray

--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -104,12 +104,12 @@ ArchLinux
 Docker
 ~~~~~~
 
-- `docker-syncthing <https://docs.linuxserver.io/images/docker-syncthing>`_ from `LinuxServer <https://www.linuxserver.io>`_
+- `docker-syncthing <https://docs.linuxserver.io/images/docker-syncthing>`_ from `LinuxServer <https://www.linuxserver.io>`__
 
 - Dockerfiles for `Syncthing <https://github.com/firecat53/dockerfiles/tree/main/syncthing>`_ and `Syncthing Discovery Server <https://github.com/firecat53/dockerfiles/tree/main/syncthing_discovery>`_.
   Latest binary releases used for both.
 
-- `docker-syncthing <https://github.com/joeybaker/docker-syncthing>`_
+- `docker-syncthing <https://github.com/joeybaker/docker-syncthing>`__
   A fully baked docker container that allows custom config and will keep your
   settings and data past docker image restarts.
 

--- a/users/firewall.rst
+++ b/users/firewall.rst
@@ -76,7 +76,7 @@ In case you installed Syncthing manually you can follow the `instructions to man
 
 Firewalld
 ~~~~~~~~~
-If you are using `Firewalld <https://www.firewalld.org/>`__ it has included
+If you are using `Firewalld <https://firewalld.org/>`__ it has included
 support for syncthing (since version 0.5.0, January 2018), and you can enable
 it with::
 

--- a/users/security.rst
+++ b/users/security.rst
@@ -17,7 +17,7 @@ file name must exist in the local index and the global model.
 
 For information about ensuring you are running the code you think you are and
 for reporting security vulnerabilities, please see the official `security page
-<https://syncthing.net/security.html>`__.
+<https://syncthing.net/security>`__.
 
 Information Leakage
 -------------------


### PR DESCRIPTION
This started as an exercise to get rid of warnings during the documentation build.  Turns out the main cause for over 70 warnings is currently https://github.com/sphinx-doc/sphinx/issues/10112 on Sphinx 4.4.0.  A hot-fix release appears to be imminent to make them opt-in.  Fixed the one legitimate warning from `extlinks` and some other linking issues along the way.

To possibly speed up the build / deployment process, limit the cloning depth for the docs-pre-rendered repo to 1, as everything else gets discarded anyway.

