### PR TITLE
Update Caddy v2 configuration docs to fix 'host check error'

### DIFF
--- a/users/reverseproxy.rst
+++ b/users/reverseproxy.rst
@@ -77,7 +77,10 @@ Caddy v2
 
     handle_path /syncthing/* {
         uri strip_prefix /syncthing
-        reverse_proxy http://localhost:8384
+        reverse_proxy http://localhost:8384 {
+                header_up Host {upstream_hostport}
+                header_up X-Forwarded-Host {host}
+        }
     }
 
 


### PR DESCRIPTION
Using the current Caddy configuration shown in the documentation, users get a host check error trying to access Syncthing's web-ui on their servers.
Adding these changes fixes that