### PR TITLE
Update Apache reverse proxy config to include X-Forwarded-Proto

### DIFF
--- a/users/reverseproxy.rst
+++ b/users/reverseproxy.rst
@@ -24,16 +24,17 @@ GUI hosted on ``localhost:8384``.
 Apache
 ~~~~~~
 
-First of all, execute the following command to enable the Apache HTTP Proxy
-module: ``a2enmod proxy_http``.
+First of all, execute the following commands to enable the Apache HTTP Proxy
+module and the headers module: ``a2enmod proxy_http headers``.
 
 Then, you may add the following to your Apache httpd configuration:
 
 .. code-block:: apache
 
-    ProxyPass /syncthing/ http://localhost:8384/
     <Location /syncthing/>
+        ProxyPass http://localhost:8384/
         ProxyPassReverse http://localhost:8384/
+        RequestHeader set "X-Forwarded-Proto" expr=%{REQUEST_SCHEME}
         Require all granted
     </Location>
 


### PR DESCRIPTION
Needed to properly handle secure cookies when using HTTPS
(see https://github.com/syncthing/syncthing/issues/7399#issuecomment-967770293)