### PR TITLE
Reserve height for version picker note early on

### DIFF
--- a/_static/version_redirect.js
+++ b/_static/version_redirect.js
@@ -99,7 +99,7 @@ function createVersionPickerNote() {
     var doc = document.getElementsByClassName('document')[0];
     doc.prepend(note);
 
-    return span;
+    return note;
 }
 
 function setVersionPickerOptions() {
@@ -119,6 +119,9 @@ function setVersionPickerOptions() {
         sel.onchange = pickVersion;
         sel.innerHTML = items.join('');
         note.style.visibility = 'visible';
+        note.childNodes[0].style.visibility = 'visible';
+    }).catch(function (available) {
+        note.style.visibility = 'hidden';
     });
 }
 

--- a/_static/version_redirect.js
+++ b/_static/version_redirect.js
@@ -87,16 +87,18 @@ function createVersionPickerNote() {
     var sel = document.createElement('select');
     sel.id = 'version-picker';
     sel.style.font = 'inherit';
+    var span = document.createElement('span');
+    span.style.visibility = 'hidden';
+    span.append('Browsing documentation for version: ');
+    span.append(sel);
     var note = document.createElement('div');
     note.id = 'version-picker-note';
     note.classList.add('admonition', 'hint');
-    note.style.visibility = 'hidden';
-    note.append('Browsing documentation for version: ');
-    note.append(sel);
+    note.append(span);
     var doc = document.getElementsByClassName('document')[0];
     doc.prepend(note);
 
-    return note;
+    return span;
 }
 
 function setVersionPickerOptions() {

--- a/_static/version_redirect.js
+++ b/_static/version_redirect.js
@@ -94,6 +94,7 @@ function createVersionPickerNote() {
     var note = document.createElement('div');
     note.id = 'version-picker-note';
     note.classList.add('admonition', 'hint');
+    note.style.textAlign = 'center';
     note.append(span);
     var doc = document.getElementsByClassName('document')[0];
     doc.prepend(note);

--- a/_static/version_redirect.js
+++ b/_static/version_redirect.js
@@ -83,7 +83,24 @@ function redirectToVersion(target, available, keepHistory) {
     redirectToPath(newPath, keepHistory);
 }
 
+function createVersionPickerNote() {
+    var sel = document.createElement('select');
+    sel.id = 'version-picker';
+    sel.style.font = 'inherit';
+    var note = document.createElement('div');
+    note.id = 'version-picker-note';
+    note.classList.add('admonition', 'hint');
+    note.style.visibility = 'hidden';
+    note.append('Browsing documentation for version: ');
+    note.append(sel);
+    var doc = document.getElementsByClassName('document')[0];
+    doc.prepend(note);
+
+    return note;
+}
+
 function setVersionPickerOptions() {
+    var note = createVersionPickerNote();
     getVersions.then(function (available) {
         var items = [
             '<option value="">latest</option>'
@@ -95,17 +112,10 @@ function setVersionPickerOptions() {
             item += '>' + val + '</option>';
             items.push(item);
         });
-        let sel = document.createElement('select');
-        sel.setAttribute('id', 'version-picker');
-        sel.setAttribute('style', 'font: inherit;');
+        var sel = document.getElementById('version-picker');
         sel.onchange = pickVersion;
         sel.innerHTML = items.join('');
-        let note = document.createElement('div');
-        note.classList.add('admonition', 'hint');
-        note.append('Browsing documentation for version: ');
-        note.append(sel);
-        var doc = document.getElementsByClassName('document')[0];
-        doc.prepend(note);
+        note.style.visibility = 'visible';
     });
 }
 


### PR DESCRIPTION
Split up the setVersionPickerOptions() function to create the
admonition elements before the versions.json list was fetched.  This
will avoid the page jumping around when the GetJSON() promise takes
some time to resolve.

Clean up some code styling along the way, using var instead of let and
direct element attribute access instead of setAttributes().