### PR TITLE
Document missing environment variables

### DIFF
--- a/includes/env-vars.rst
+++ b/includes/env-vars.rst
@@ -100,13 +100,13 @@ STHEAPPROFILE
 STNODEFAULTFOLDER
     Don't create a default folder when starting for the first time. This
     variable will be ignored anytime after the first run.  Equivalent to the
-    ``--no-default-folder`` flag.
+    :option:`--no-default-folder` flag.
 
 STNORESTART
-    Equivalent to the ``--no-restart`` flag.
+    Equivalent to the :option:`--no-restart` flag.
 
 STNOUPGRADE
-    Disable automatic upgrades.  Equivalent to the ``--no-upgrade`` flag.
+    Disable automatic upgrades.  Equivalent to the :option:`--no-upgrade` flag.
 
 STPROFILER
     Set to a listen address such as "127.0.0.1:9090" to start the profiler with

--- a/includes/env-vars.rst
+++ b/includes/env-vars.rst
@@ -77,6 +77,13 @@ STDEADLOCKTHRESHOLD
     Used for debugging internal deadlocks; sets debug sensitivity. Use only
     under direction of a developer.
 
+STGUIADDRESS
+    Override GUI listen address.  Equivalent to passing :option:`--gui-address`.
+
+STGUIAPIKEY
+    Override the API key needed to access the GUI / REST API.  Equivalent to
+    passing :option:`--gui-apikey`.
+
 STGUIASSETS
     Directory to load GUI assets from. Overrides compiled in assets. Useful for
     developing webgui, commonly use ``STGUIASSETS=gui bin/syncthing``.

--- a/includes/env-vars.rst
+++ b/includes/env-vars.rst
@@ -73,7 +73,7 @@ STDEADLOCKTIMEOUT
     Used for debugging internal deadlocks; sets debug sensitivity. Use only
     under direction of a developer.
 
-STDEADLOCKTHRESHOLD
+STLOCKTHRESHOLD
     Used for debugging internal deadlocks; sets debug sensitivity. Use only
     under direction of a developer.
 

--- a/includes/env-vars.rst
+++ b/includes/env-vars.rst
@@ -120,9 +120,13 @@ STPERFSTATS
 
 STRECHECKDBEVERY
     Time before folder statistics (file, dir, ... counts) are recalculated from
-    scratch. The given duration must be parseable by Go's time.ParseDuration. If
+    scratch. The given duration must be parseable by Go's ``time.ParseDuration``. If
     missing or not parseable, the default value of 1 month is used. To force
     recalculation on every startup, set it to ``1s``.
+
+STGCINDIRECTEVERY
+    Sets the time interval in between database garbage collection runs.  The
+    given duration must be parseable by Go's ``time.ParseDuration``.
 
 GOMAXPROCS
     Set the maximum number of CPU cores to use. Defaults to all available CPU

--- a/includes/env-vars.rst
+++ b/includes/env-vars.rst
@@ -132,3 +132,7 @@ GOGC
     Percentage of heap growth at which to trigger GC. Default is 100. Lower
     numbers keep peak memory usage down, at the price of CPU usage
     (i.e. performance).
+
+LOGGER_DISCARD
+    Hack to completely disable logging, for example when running benchmarks.
+    Set to any nonempty value to use it.


### PR DESCRIPTION
Some more cleanup along the way, including cross-references to the already mentioned CLI options.