### PR TITLE
events, rest: Add missing fields to FolderCompletion.

### DIFF
--- a/events/foldercompletion.rst
+++ b/events/foldercompletion.rst
@@ -16,6 +16,12 @@ device.
         "data": {
             "completion": 100,
             "device": "I6KAH76-66SLLLB-5PFXSOA-UFJCDZC-YAOMLEK-CP2GB32-BV5RQST-3PSROAU",
-            "folder": "default"
+            "folder": "default",
+            "globalBytes": 17,
+            "globalItems": 4,
+            "needBytes": 0,
+            "needDeletes": 0,
+            "needItems": 0,
+            "sequence": 12
         }
     }

--- a/rest/db-completion-get.rst
+++ b/rest/db-completion-get.rst
@@ -43,7 +43,8 @@ Example Response
       "needBytes": 9789241,
       "globalItems": 7823,
       "needItems": 412,
-      "needDeletes": 0
+      "needDeletes": 0,
+      "sequence": 12
     }
 
 .. versionadded:: 1.8.0


### PR DESCRIPTION
The example response was incomplete for the `FolderCompletion` event.  In `/rest/db/completion`, the fields were mostly present, except for the `sequence` number.