### PR TITLE
Deployment fixes

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -63,7 +63,7 @@ copyright = u'2014-2019, The Syncthing Authors'
 #
 # The full version, including alpha/beta/rc tags.
 try:
-    release = os.popen('git describe --tags --long --always --dirty').read().strip()
+    release = os.popen('git describe --tags --long --always').read().strip()
 except Exception:
     release = 'v1'
 # The short X.Y version.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-sphinx>=4.0.0
+sphinx==4.4.0
+docutils==0.17.1


### PR DESCRIPTION
Avoid `-dirty` string in displayed git version, which could inevitably occur when back-porting any future changes to the docs-pre-rendered repo.

Adjust build tools version requirements to not end up with older versions than what the other repo was built with.