### PR TITLE
events: Mention events not in the default event type mask (fixes #404)

### DIFF
--- a/events/localchangedetected.rst
+++ b/events/localchangedetected.rst
@@ -6,8 +6,8 @@ previous scan.  This does *not* include events that are discovered and copied fr
 other devices (:doc:`remotechangedetected`), only files that were changed on the
 local filesystem.
 
-.. note:: This is not included in the default mask for the
-   :doc:`/rest/events-get` endpoint,but needs to be selected explicitly.
+.. note:: This event is not included in :doc:`/rest/events-get` endpoint without
+   a mask specified, but needs to be selected explicitly.
 
 .. code-block:: json
 

--- a/events/localchangedetected.rst
+++ b/events/localchangedetected.rst
@@ -1,12 +1,13 @@
-.. _local-change-detected:
-
 LocalChangeDetected
 -------------------
 
 Generated upon scan whenever the local disk has discovered an updated file from the
 previous scan.  This does *not* include events that are discovered and copied from
-other devices (:ref:`remote-change-detected`), only files that were changed on the
+other devices (:doc:`remotechangedetected`), only files that were changed on the
 local filesystem.
+
+.. note:: This is not included in the default mask for the
+   :doc:`/rest/events-get` endpoint,but needs to be selected explicitly.
 
 .. code-block:: json
 

--- a/events/remotechangedetected.rst
+++ b/events/remotechangedetected.rst
@@ -4,8 +4,8 @@ RemoteChangeDetected
 Generated upon scan whenever a file is locally updated due to a remote change.
 Files that are updated locally produce a :doc:`localchangedetected` event.
 
-.. note:: This is not included in the default mask for the
-   :doc:`/rest/events-get` endpoint,but needs to be selected explicitly.
+.. note:: This event is not included in :doc:`/rest/events-get` endpoint without
+   a mask specified, but needs to be selected explicitly.
 
 .. code-block:: json
 

--- a/events/remotechangedetected.rst
+++ b/events/remotechangedetected.rst
@@ -1,10 +1,11 @@
-.. _remote-change-detected:
-
 RemoteChangeDetected
 --------------------
 
 Generated upon scan whenever a file is locally updated due to a remote change.
-Files that are updated locally produce a :ref:`local-change-detected` event.
+Files that are updated locally produce a :doc:`localchangedetected` event.
+
+.. note:: This is not included in the default mask for the
+   :doc:`/rest/events-get` endpoint,but needs to be selected explicitly.
 
 .. code-block:: json
 

--- a/rest/events-get.rst
+++ b/rest/events-get.rst
@@ -3,9 +3,11 @@ GET /rest/events
 
 To receive events, perform a HTTP GET of ``/rest/events``.
 
-To filter the event list, in effect creating a specific subscription for
-only the desired event types, add a parameter
-``events=EventTypeA,EventTypeB,...`` where the event types are any of the :ref:`event-types`.
+To filter the event list, in effect creating a specific subscription for only
+the desired event types, add a parameter ``events=EventTypeA,EventTypeB,...``
+where the event types are any of the :ref:`event-types`.  If no filter is
+specified, all events *except* :doc:`/events/localchangedetected` and
+:doc:`/events/remotechangedetected` are included.
 
 The optional parameter ``since=<lastSeenID>`` sets the ID of the last event
 you've already seen. Syncthing returns a JSON encoded array of event objects,


### PR DESCRIPTION
Add a note to LocalChangeDetected and RemoteChangeDetected events
about needing to explicitly select them on the /rest/events endpoint.

Simplify cross-references along the way.