### PR TITLE
events, rest: Add DEPRECATED suffix in titles as needed.

### DIFF
--- a/events/devicerejected.rst
+++ b/events/devicerejected.rst
@@ -1,9 +1,9 @@
-DeviceRejected
---------------
+DeviceRejected (DEPRECATED)
+---------------------------
 
 .. deprecated:: v1.13.0
    This event is still emitted for compatibility, but deprecated.  Use
-   the replacement :ref:`pending-devices-changed` event instead.
+   the replacement :doc:`pendingdeviceschanged` event instead.
 
 Emitted when there is a connection from a device we are not configured
 to talk to.

--- a/events/folderrejected.rst
+++ b/events/folderrejected.rst
@@ -1,9 +1,9 @@
-FolderRejected
---------------
+FolderRejected (DEPRECATED)
+---------------------------
 
 .. deprecated:: v1.13.0
    This event is still emitted for compatibility, but deprecated.  Use
-   the replacement :ref:`pending-folders-changed` event instead.
+   the replacement :doc:`pendingfolderschanged` event instead.
 
 Emitted when a device sends index information for a folder we do not
 have, or have but do not share with the device in question.

--- a/events/pendingdeviceschanged.rst
+++ b/events/pendingdeviceschanged.rst
@@ -1,5 +1,3 @@
-.. _pending-devices-changed:
-
 PendingDevicesChanged
 ---------------------
 

--- a/events/pendingfolderschanged.rst
+++ b/events/pendingfolderschanged.rst
@@ -1,5 +1,3 @@
-.. _pending-folders-changed:
-
 PendingFoldersChanged
 ---------------------
 

--- a/rest/folder-pullerrors-get.rst
+++ b/rest/folder-pullerrors-get.rst
@@ -1,5 +1,5 @@
-GET /rest/folder/pullerrors
-===========================
+GET /rest/folder/pullerrors (DEPRECATED)
+========================================
 
 .. deprecated:: v0.14.53
    This endpoint still works as before but is deprecated.  Use

--- a/rest/system-config-get.rst
+++ b/rest/system-config-get.rst
@@ -1,5 +1,5 @@
-GET /rest/system/config
-=======================
+GET /rest/system/config (DEPRECATED)
+====================================
 
 .. deprecated:: v1.12.0
    This endpoint still works as before but is deprecated. Use :ref:`rest-config`

--- a/rest/system-config-insync-get.rst
+++ b/rest/system-config-insync-get.rst
@@ -1,5 +1,5 @@
-GET /rest/system/config/insync
-==============================
+GET /rest/system/config/insync (DEPRECATED)
+===========================================
 
 .. deprecated:: v1.12.0
    This endpoint still works as before but is deprecated. Use

--- a/rest/system-config-post.rst
+++ b/rest/system-config-post.rst
@@ -1,8 +1,8 @@
-POST /rest/system/config
-========================
+POST /rest/system/config (DEPRECATED)
+=====================================
 
 .. deprecated:: v1.12.0
-   This endpoint still works as before but is deprecated. Use :ref:`rest-config`
+   This endpoint still works as before but is deprecated.  Use :doc:`config`
    instead.
 
 Post the full contents of the configuration, in the same format as returned by


### PR DESCRIPTION
Simplify some cross-references to the replacement APIs.

Ref #678.