### PR TITLE
users/contrib: Add Syncthing Windows Setup by Bill-Stewart.

### DIFF
--- a/users/autostart.rst
+++ b/users/autostart.rst
@@ -187,7 +187,8 @@ an option to start the program automatically, and a more polished user
 experience (e.g. by behaving as a "proper" Windows application, rather
 than forcing you to start a Web browser to interact with Syncthing).
 
-.. seealso:: :ref:`Windows GUI Wrappers <contrib-windows>`, :ref:`Cross-platform GUI Wrappers <contrib-all>`.
+.. seealso:: :ref:`Windows GUI Wrappers <contrib-windows>`, :ref:`Cross-platform GUI
+  Wrappers <contrib-all>`, :ref:`Windows Packages <contrib-packages-windows>`.
 
 .. _autostart-windows-service:
 

--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -87,6 +87,18 @@ Cross-platform
 
     > curl.exe -A MS https://webinstall.dev/syncthing | powershell
 
+.. _contrib-packages-windows:
+
+Windows
+~~~~~~~
+
+- `Syncthing Windows Setup <https://github.com/Bill-Stewart/SyncthingWindowsSetup>`_
+
+  A lightweight yet full-featured Windows installer built using Inno Setup.  Support both
+  admin and regular user installation, auto-start, firewall integration as well as silent
+  installation.
+
+
 Debian / Ubuntu
 ~~~~~~~~~~~~~~~
 

--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -94,7 +94,7 @@ Windows
 
 - `Syncthing Windows Setup <https://github.com/Bill-Stewart/SyncthingWindowsSetup>`_
 
-  A lightweight yet full-featured Windows installer built using Inno Setup.  Support both
+  A lightweight yet full-featured Windows installer built using Inno Setup.  Supports both
   admin and regular user installation, auto-start, firewall integration as well as silent
   installation.
 


### PR DESCRIPTION
Add a new section under "Packages and Bundlings" for Windows, since
this doesn't really belong under GUI wrappers.  Link to the section
from the existing auto-start docs.