### PR TITLE
conf: Hide the version from title unless it exactly matches a tag (fixes #748)

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -64,8 +64,10 @@ copyright = u'2014-2019, The Syncthing Authors'
 # The full version, including alpha/beta/rc tags.
 try:
     release = os.popen('git describe --tags --long --always').read().strip()
+    _git_tag = os.popen('git describe --tags --exact-match').read().strip()
 except Exception:
     release = 'v1'
+    _git_tag = ''
 # The short X.Y version.
 version = release.partition('-')[0]
 
@@ -148,7 +150,10 @@ html_theme_path = ['_themes']
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+if version == _git_tag:
+    html_title = f'{project} {version} documentation'
+else:
+    html_title = f'{project} documentation'
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #html_short_title = None


### PR DESCRIPTION
Find out during build whether the source is currently described by a
Git tag.  Show that (shorter than the "release" info), or no version
at all otherwise.