### PR TITLE
Default ignores configuration (fixes #712)

### DIFF
--- a/includes/cli-commands.rst
+++ b/includes/cli-commands.rst
@@ -15,7 +15,8 @@ show
 
 operations
     Control the overall program operation such as restarting or handling
-    upgrades, as well as triggering some actions on a per-folder basis.
+    upgrades, as well as triggering some actions on a per-folder basis.  Can
+    also configure the default ignore patterns from a plain text ignore file.
 
 errors
     Examine pending error conditions that need attention from the user, or

--- a/users/config.rst
+++ b/users/config.rst
@@ -1347,10 +1347,10 @@ be present in the ``defaults`` element:
     .. versionadded:: 1.19.0
 
     Template for the :ref:`ignore patterns <ignoring-files>` applied to new
-    folders.  These are automatically copied to the ``.stignore`` file when a
-    folder is automatically accepted from a remote device.  The GUI uses them to
-    pre-fill the respective field when adding a new folder as well.  In XML,
-    each pattern line is represented as by a ``<line>`` element.
+    folders.  These are copied to the ``.stignore`` file when a folder is
+    automatically accepted from a remote device.  The GUI uses them to pre-fill
+    the respective field when adding a new folder as well.  In XML, each pattern
+    line is represented as by a ``<line>`` element.
 
 
 .. _listen-addresses:

--- a/users/config.rst
+++ b/users/config.rst
@@ -1309,6 +1309,13 @@ Defaults Element
             <untrusted>false</untrusted>
             <remoteGUIPort>0</remoteGUIPort>
         </device>
+	<ignores>
+            <line>!foo2</line>
+            <line>// comment</line>
+            <line>(?d).DS_Store</line>
+            <line>*2</line>
+            <line>qu*</line>
+        </ignores>
     </defaults>
 
 The ``defaults`` element describes a template for newly added device and folder
@@ -1334,6 +1341,16 @@ be present in the ``defaults`` element:
 
     Even sharing with other remote devices can be done in the template by
     including the appropriate :opt:`folder.device` element underneath.
+
+.. option:: defaults.ignores
+
+    .. versionadded:: 1.19.0
+
+    Template for the :ref:`ignore patterns <ignoring-files>` applied to new
+    folders.  These are automatically copied to the ``.stignore`` file when a
+    folder is automatically accepted from a remote device.  The GUI uses them to
+    pre-fill the respective field when adding a new folder as well.  In XML,
+    each pattern line is represented as by a ``<line>`` element.
 
 
 .. _listen-addresses:

--- a/users/config.rst
+++ b/users/config.rst
@@ -1309,7 +1309,7 @@ Defaults Element
             <untrusted>false</untrusted>
             <remoteGUIPort>0</remoteGUIPort>
         </device>
-	<ignores>
+        <ignores>
             <line>!foo2</line>
             <line>// comment</line>
             <line>(?d).DS_Store</line>

--- a/users/ignoring.rst
+++ b/users/ignoring.rst
@@ -161,3 +161,10 @@ all files and directories called "foo", ending in a "2" or starting with
   ``some/directory/`` matches the content of the directory, but not the
   directory itself. If you want the pattern to match the directory and its
   content, make sure it does not have a ``/`` at the end of the pattern.
+
+.. versionadded:: 1.19.0
+
+   Default patterns can be configured which will take effect when automatically
+   accepting a folder from a remote device.  The GUI suggests same the patterns
+   when adding a folder manually.  In either case, the ``.stignore`` file is
+   created with these defaults if none is present yet.


### PR DESCRIPTION
Describe the format of the `<defaults><ignores>` XML structure.  Explain when it gets used in the section about ignoring files.

Extend CLI subcommand description to mention the `syncthing cli operations default-ignores` method, albeit without naming the command.  The possibilites in there are meant to be discovered by the help functions, so we only give a rough hint here in the overview.