### PR TITLE
users/config: Add alias for the defaults.ignores.lines element

### DIFF
--- a/users/config.rst
+++ b/users/config.rst
@@ -1343,6 +1343,7 @@ be present in the ``defaults`` element:
     including the appropriate :opt:`folder.device` element underneath.
 
 .. option:: defaults.ignores
+    :aliases: defaults.ignores.lines
 
     .. versionadded:: 1.19.0
 


### PR DESCRIPTION
Ref https://github.com/syncthing/syncthing/pull/8265

When systematically generating the links, this will be the name coming from the config's JSON serialization format.