### PR TITLE
events: Add missing and mark deprecated fields

### DIFF
--- a/events/localchangedetected.rst
+++ b/events/localchangedetected.rst
@@ -18,9 +18,14 @@ local filesystem.
     "type": "LocalChangeDetected",
     "data": {
       "action": "deleted",
+      "folder": "vitwy-zjxqt",
       "folderID": "vitwy-zjxqt",
       "label": "TestSync",
       "path": "C:\\Users\\Nate\\Sync\\testfolder\\test file.rtf",
       "type": "file"
     }
   }
+
+.. deprecated:: v1.1.2
+  The ``folderID`` field is a legacy name kept only for compatibility.  Use the
+  ``folder`` field with identical content instead.

--- a/events/localindexupdated.rst
+++ b/events/localindexupdated.rst
@@ -15,5 +15,16 @@ changes during a scan.
         "data": {
             "folder": "default",
             "items": 1000,
+            "filenames": [
+                "foo",
+                "bar",
+                "baz"
+            ],
+            "sequence": 12345,
+            "version": 12345
         }
     }
+
+.. deprecated:: v1.10.0
+  The ``version`` field is a legacy name kept only for compatibility.  Use the
+  ``sequence`` field with identical content instead.

--- a/events/remotechangedetected.rst
+++ b/events/remotechangedetected.rst
@@ -15,11 +15,16 @@ Files that are updated locally produce a :doc:`localchangedetected` event.
       "data" : {
          "type" : "file",
          "action" : "deleted",
+         "folder": "Dokumente",
+         "folderID" : "Dokumente",
          "path" : "/media/ntfs_data/Dokumente/testfile",
          "label" : "Dokumente",
-         "folderID" : "Dokumente",
          "modifiedBy" : "BPDFDTU"
       },
       "type" : "RemoteChangeDetected",
       "id" : 2
    }
+
+.. deprecated:: v1.1.2
+  The ``folderID`` field is a legacy name kept only for compatibility.  Use the
+  ``folder`` field with identical content instead.


### PR DESCRIPTION
Some archaeologic work on fields added to the Event API.