### PR TITLE
Update running on port 443 as unprivileged user

### DIFF
--- a/users/strelaysrv.rst
+++ b/users/strelaysrv.rst
@@ -168,7 +168,7 @@ there are a couple of approaches available to you.
 One option is to run the relay on port 22067, and use an ``iptables`` rule
 to forward traffic from port 443 to port 22067, for example::
 
-    iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 443 -j REDIRECT --to-port 22067
+    iptables -t nat -A PREROUTING -p tcp --dport 443 -j REDIRECT --to-port 22067
 
 Or, if you're using ``ufw``, add the following to ``/etc/ufw/before.rules``::
 
@@ -176,7 +176,7 @@ Or, if you're using ``ufw``, add the following to ``/etc/ufw/before.rules``::
     :PREROUTING ACCEPT [0:0]
     :POSTROUTING ACCEPT [0:0]
 
-    -A PREROUTING -i eth0 -p tcp --dport 443 -j REDIRECT --to-port 22067
+    -A PREROUTING -p tcp --dport 443 -j REDIRECT --to-port 22067
 
     COMMIT
 


### PR DESCRIPTION
Removed the filter `-i eth0' since predictable network interface names like ens2 are nowadays common. This makes it easier for most of the users setting up a working relay server on Port 443, since copy and paste now works. More advanced users with multiple NICs should be familiar with iptables more and can add the NIC filter on their own.