### PR TITLE
Update IP in reverse proxy page

### DIFF
--- a/users/reverseproxy.rst
+++ b/users/reverseproxy.rst
@@ -19,7 +19,7 @@ Server Configuration
 
 If you have access to your web server's configuration use the following
 examples to pass the location ``/syncthing`` on your web server to Syncthing's
-GUI hosted on ``localhost:8384``.
+GUI hosted on ``127.0.0.1:8384``.
 
 Apache
 ~~~~~~
@@ -32,8 +32,8 @@ Then, you may add the following to your Apache httpd configuration:
 .. code-block:: apache
 
     <Location /syncthing/>
-        ProxyPass http://localhost:8384/
-        ProxyPassReverse http://localhost:8384/
+        ProxyPass http://127.0.0.1:8384/
+        ProxyPassReverse http://127.0.0.1:8384/
         RequestHeader set "X-Forwarded-Proto" expr=%{REQUEST_SCHEME}
         Require all granted
     </Location>
@@ -49,7 +49,7 @@ Nginx
       proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header        X-Forwarded-Proto $scheme;
 
-      proxy_pass              http://localhost:8384/;
+      proxy_pass              http://127.0.0.1:8384/;
 
       proxy_read_timeout      600s;
       proxy_send_timeout      600s;
@@ -60,7 +60,7 @@ Caddy
 
 .. code-block:: none
 
-    proxy /syncthing localhost:8384 {
+    proxy /syncthing 127.0.0.1:8384 {
         transparent
     }
 
@@ -78,7 +78,7 @@ Caddy v2
 
     handle_path /syncthing/* {
         uri strip_prefix /syncthing
-        reverse_proxy http://localhost:8384 {
+        reverse_proxy http://127.0.0.1:8384 {
                 header_up Host {upstream_hostport}
                 header_up X-Forwarded-Host {host}
         }
@@ -104,7 +104,7 @@ behaviour as above
     RewriteCond %{HTTPS} !=on
     RewriteCond %{ENV:HTTPS} !=on
     RewriteRule .* https://%{SERVER_NAME}%{REQUEST_URI} [R=301,L]
-    RewriteRule ^(.*) http://localhost:8384/$1 [P]
+    RewriteRule ^(.*) http://127.0.0.1:8384/$1 [P]
 
 
 This method also redirects to HTTPS to prevent opening the GUI unencrypted.


### PR DESCRIPTION
Using `127.0.0.1` instead of `localhost` fixed long 502 errors on nginx for me.
On systems where both IPv4 and IPv6 is enabled, this seems cause issues.
See [here](https://stackoverflow.com/a/72188777) for an explanation.