### PR TITLE
users, advanced: Mention systemd capability settings.

### DIFF
--- a/advanced/folder-sync-ownership.rst
+++ b/advanced/folder-sync-ownership.rst
@@ -57,6 +57,10 @@ Example commands of setting Syncthing up in this manner::
 .. note:: Note that automated upgrades cannot be used with Syncthing elevated
    in this manner as any automated upgrade would undo the capabilities granted.
 
+When using systemd to start the service automatically, the capabilities can be
+set in the unit file instead of touching the executable, see
+:ref:`autostart-systemd-permissions`.
+
 Windows implementation
 ----------------------
 

--- a/users/autostart.rst
+++ b/users/autostart.rst
@@ -439,6 +439,8 @@ To see the logs for the user service::
 
     journalctl -e --user-unit=syncthing.service
 
+.. _autostart-systemd-permissions:
+
 Permissions
 ^^^^^^^^^^^
 
@@ -446,6 +448,15 @@ If you enabled the ``Ignore Permissions`` option in the Syncthing client's
 folder settings, then you will also need to add the line ``UMask=0002`` (or any
 other `umask setting <https://www.tech-faq.com/umask.html>`_ you like) in the
 ``[Service]`` section of the ``syncthing@.service`` file.
+
+For the :doc:`/advanced/folder-sync-ownership` option to work, you can
+grant extra capabilities to the service via the systemd unit file.
+Add the following snippet to the service file (commented out in the
+provided template).  To ensure smooth upgrades, keeping it in an
+override file using ``systemd edit ...`` is advised::
+
+    [Service]
+    AmbientCapabilities=CAP_CHOWN CAP_FOWNER
 
 Debugging
 ^^^^^^^^^


### PR DESCRIPTION
The `syncOwnership` feature needs elevated permissions to work on Linux. As an alternative to setting caps on the executable, point to the systemd configuration page and suggest the relevant `AmbientCapabilities` setting there.

Based on info from https://forum.syncthing.net/t/problem-with-syncownership/18934/5