### PR TITLE
Inclusion of my tray icon script into Community Contributions/Linux section

### DIFF
--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -66,7 +66,7 @@ Linux
 
   Small bash application with minimal dependencies, for a simple colorful representation of the current status.
   
-- `syncthing-quick-status <https://github.com/abdeoliveira/syncthing-tray-gtk3>`_
+- `syncthing-tray-gtk3 <https://github.com/abdeoliveira/syncthing-tray-gtk3>`_
 
   Yet another Syncthing tray icon indicator written in Ruby.
 

--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -65,6 +65,10 @@ Linux
 - `syncthing-quick-status <https://github.com/serl/syncthing-quick-status>`_
 
   Small bash application with minimal dependencies, for a simple colorful representation of the current status.
+  
+- `syncthing-quick-status <https://github.com/abdeoliveira/syncthing-tray-gtk3>`_
+
+  Yet another Syncthing tray icon indicator written in Ruby.
 
 Command Line Tools
 ------------------


### PR DESCRIPTION
I  added a line into Community Contributions (Linux) section pointing to my github project for a Syncthing tray icon indicator (GTK) written in Ruby.