### PR TITLE
dev/rest: added documentation for noauth

### DIFF
--- a/dev/rest.rst
+++ b/dev/rest.rst
@@ -116,7 +116,7 @@ Debug Endpoints
 Noauth Endpoints
 ----------------
 
-Calls that do not require authentication
+Calls that do not require authentication.
 
 .. toctree::
    :maxdepth: 1

--- a/dev/rest.rst
+++ b/dev/rest.rst
@@ -120,6 +120,5 @@ Calls that do not require authentication
 
 .. toctree::
    :maxdepth: 1
-   :glob:
 
    /rest/noauth/... <../rest/noauth.rst>

--- a/dev/rest.rst
+++ b/dev/rest.rst
@@ -16,6 +16,9 @@ the configuration file. To use an API key, set the request header
 "X-API-Key: abc123" http://localhost:8384/rest/...`` can be used to invoke
 with ``curl`` (add ``-k`` flag when using HTTPS with a Syncthing generated or self signed certificate).
 
+One exception to this requirement is ``/rest/noauth``, you do not need an API
+key to use those endpoints.
+
 .. _rest-pagination:
 
 Result Pagination
@@ -109,3 +112,14 @@ Debug Endpoints
    :maxdepth: 1
 
    /rest/debug/... <../rest/debug.rst>
+
+Noauth Endpoints
+----------------
+
+Calls that do not require authentication
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   /rest/noauth/... <../rest/noauth.rst>

--- a/rest/noauth.rst
+++ b/rest/noauth.rst
@@ -1,0 +1,17 @@
+Noauth Endpoints
+================
+
+These endpoints do not require being authenticated or an API key to be used.
+This way third-party services and devices can make calls like a health-check
+without needing to share your API key or credentials.
+
+GET /rest/noauth/health
+-----------------------
+
+Returns a ``{"status": "OK"}`` object.
+
+.. code-block:: json
+
+    {
+      "status": "OK"
+    }


### PR DESCRIPTION
Added documentation to support recently made changes to the REST API (Syncthing PR: #8585).

- Added a short explanatory remark where the requirement of having a set API KEY is being explained to clarify the exception-case which 'noauth' is;
- Then I added a page with a short general explanation the purpose of /rest/noauth;
- And I included the actual endpoint "health", explaining what it returns.

I noticed that there are two ways to implement this, but since a slight general explanation was (imo) preferred I chose a path similar to  /rest/config and /rest/debug.

Also I noticed an inconsistency in the identation-level in code blocks regarding json, so I wasn't entirely sure which one would be preferred.