### PR TITLE
users/syncing: Add note about Syncthing namespace

### DIFF
--- a/users/faq-parts/general.rst
+++ b/users/faq-parts/general.rst
@@ -47,6 +47,8 @@ The following are *not* synchronized;
 -  Windows ACLs (not preserved)
 -  Devices, FIFOs, and other specials (ignored)
 -  Sparse file sparseness (will become sparse, when supported by the OS & filesystem)
+-  Syncthing internal files and folders (e.g. ``.stfolder``, ``.stignore``,
+   ``.stversions``, :ref:`temporary files <temporary-files>`, etc.)
 
 Is synchronization fast?
 ------------------------

--- a/users/syncing.rst
+++ b/users/syncing.rst
@@ -149,3 +149,11 @@ The temporary files are named ``.syncthing.original-filename.ext.tmp`` or,
 on Windows, ``~syncthing~original-filename.ext.tmp`` where
 ``original-filename.ext`` is the destination filename. The temporary file is
 normally hidden. If the temporary file name would be too long due to the addition of the prefix and extra extension, the temporary files are named ``.syncthing.<hash>.tmp`` or, on Windows, ``~syncthing~<hash>.tmp`` where ``<hash>`` is a SHA-256 hash of the original filename.
+
+.. note::
+
+    Note that the two prefixes ``.syncthing.`` and ``~syncthing~`` are
+    considered Syncthing namespace, meaning that any files whose names
+    start with them will automatically be ignored and excluded from
+    synchronisation by Syncthing. Please avoid using these prefixes in
+    your filenames if you want those files to be synchronized.

--- a/users/syncing.rst
+++ b/users/syncing.rst
@@ -156,4 +156,4 @@ normally hidden. If the temporary file name would be too long due to the additio
     considered Syncthing namespace, meaning that any files whose names
     start with them will automatically be ignored and excluded from
     synchronisation by Syncthing. Please avoid using these prefixes in
-    your filenames if you want those files to be synchronized.
+    your filenames.


### PR DESCRIPTION
Add a note about how files starting with any of the two prefixes `.syncthing.` and `~syncthing~` are ignored and not synchronised.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>