### PR TITLE
Improve clarity: exclusively from rather than of

### DIFF
--- a/users/relaying.rst
+++ b/users/relaying.rst
@@ -19,7 +19,7 @@ communicating via the relay.
 Configuring clients
 -------------------
 
-Syncthing can be configured to use specific relay servers (exclusively of the public pool) by adding the required servers to the Sync Protocol Listen Address field, under Actions and Settings. The format is as follows::
+Syncthing can be configured to use specific relay servers (exclusively from the public pool) by adding the required servers to the Sync Protocol Listen Address field, under Actions and Settings. The format is as follows::
 
   relay://<host name|IP>[:port]/?id=<relay device ID>
 

--- a/users/strelaysrv.rst
+++ b/users/strelaysrv.rst
@@ -146,7 +146,7 @@ procedure for your operating system.
 Client configuration
 ~~~~~~~~~~~~~~~~~~~~
 
-Syncthing can be configured to use specific relay servers (exclusively of the public pool) by adding the required servers to the Sync Protocol Listen Address field, under Actions and Settings. The format is as follows::
+Syncthing can be configured to use specific relay servers (exclusively from the public pool) by adding the required servers to the Sync Protocol Listen Address field, under Actions and Settings. The format is as follows::
 
   relay://<host name|IP>[:port]/?id=<relay device ID>
 


### PR DESCRIPTION
I read this in the docs:

> Syncthing can be configured to use specific relay servers **(exclusively of the public pool)** by adding the required servers to the Sync Protocol Listen Address field, under Actions and Settings.

I'm not sure what "exclusively of the public pool" means in this context. Does it mean that in addition to the public pool relay servers any additional servers can be specified? Or does it mean that only servers from the public pool can be used? As in, this option supports servers exclusively sourced from the public pool.

I chose to interpret the meaning as the latter. I thus created a PR which changes the word "of" to "from". I think this greatly improves the clarity of the sentence. However, I stress again, **I don't know which option is actually correct**. So I hope somebody who knows the correct answer can review this PR to ensure that it doesn't end up making the docs less accurate.