### PR TITLE
Update contrib openSUSE packages

### DIFF
--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -177,7 +177,7 @@ Official ports: `syncthing <https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/net/
 OpenSUSE
 ~~~~~~~~
 
-Official packages: `syncthing <https://software.opensuse.org/package/syncthing>`__ and `syncthingtray <https://software.opensuse.org/package/syncthingtray>`__
+Official packages: `syncthing <https://software.opensuse.org/package/syncthing>`__ and `qsyncthingtray <https://software.opensuse.org/package/qsyncthingtray>`__
 
 Synology NAS (DSM)
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
There's no official openSUSE package for syncthingtray but is for qsyncthingtray