### PR TITLE
fix: remove `strip uri_prefix` from Caddy V2 reverse proxy

### DIFF
--- a/users/reverseproxy.rst
+++ b/users/reverseproxy.rst
@@ -77,10 +77,8 @@ Caddy v2
 .. code-block:: none
 
     handle_path /syncthing/* {
-        uri strip_prefix /syncthing
         reverse_proxy http://localhost:8384 {
                 header_up Host {upstream_hostport}
-                header_up X-Forwarded-Host {host}
         }
     }
 


### PR DESCRIPTION
resolves #784 