### PR TITLE
all: Fix deprecated extlinks syntax for Sphinx 6.0

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -114,9 +114,9 @@ todo_include_todos = True
 
 # Configure external links.
 extlinks = {
-    'issue': ('https://github.com/syncthing/syncthing/issues/%s', 'issue #'),
-    'user': ('https://github.com/%s', '@'),
-    'commit': ('https://github.com/syncthing/syncthing/commit/%s', ''),
+    'issue': ('https://github.com/syncthing/syncthing/issues/%s', 'issue #%s'),
+    'user': ('https://github.com/%s', '@%s'),
+    'commit': ('https://github.com/syncthing/syncthing/commit/%s', None),
 }
 
 # -- Options for HTML output ----------------------------------------------


### PR DESCRIPTION
The old syntax no longer works on recent Sphinx versions - see https://github.com/sphinx-doc/sphinx/issues/11094

Fails with:

```
Exception occurred:

  File "/home/max/.local/lib/python3.10/site-packages/sphinx/ext/extlinks.py", line 103, in role

    title = caption % part

TypeError: not all arguments converted during string formatting
```

Not 100% sure if the newer syntax works on all old versions, but if this PR builds fine this should be good to go? In any case, if we ever want to upgrade the Sphinx version (we probably should at some point), this is required.