### PR TITLE
rest, users: Remove deprecated restartOnWakeup (#813)

### DIFF
--- a/rest/system-config-get.rst
+++ b/rest/system-config-get.rst
@@ -144,7 +144,6 @@ Returns the current configuration.
 	"urURL": "https://data.syncthing.net/newdata",
 	"urPostInsecurely": false,
 	"urInitialDelayS": 1800,
-	"restartOnWakeup": true,
 	"autoUpgradeIntervalH": 12,
 	"upgradeToPreReleases": false,
 	"keepTemporariesH": 24,

--- a/users/config.rst
+++ b/users/config.rst
@@ -157,7 +157,6 @@ The following shows an example of a default configuration file (IDs will differ)
             <urURL>https://data.syncthing.net/newdata</urURL>
             <urPostInsecurely>false</urPostInsecurely>
             <urInitialDelayS>1800</urInitialDelayS>
-            <restartOnWakeup>true</restartOnWakeup>
             <autoUpgradeIntervalH>12</autoUpgradeIntervalH>
             <upgradeToPreReleases>false</upgradeToPreReleases>
             <keepTemporariesH>24</keepTemporariesH>
@@ -978,7 +977,6 @@ Options Element
         <urURL>https://data.syncthing.net/newdata</urURL>
         <urPostInsecurely>false</urPostInsecurely>
         <urInitialDelayS>1800</urInitialDelayS>
-        <restartOnWakeup>true</restartOnWakeup>
         <autoUpgradeIntervalH>12</autoUpgradeIntervalH>
         <upgradeToPreReleases>false</upgradeToPreReleases>
         <keepTemporariesH>24</keepTemporariesH>
@@ -1115,11 +1113,6 @@ The ``options`` element contains all other global configuration options.
 
     The time to wait from startup for the first usage report to be sent. Allows
     the system to stabilize before reporting statistics.
-
-.. option:: options.restartOnWakeup
-
-    Whether to perform a restart of Syncthing when it is detected that we are
-    waking from sleep mode (i.e. an unfolding laptop).
 
 .. option:: options.autoUpgradeIntervalH
 


### PR DESCRIPTION
rest/system-config-get, users/config: Remove deprecated restartOnWakeup (#813)

The option "restartOnWakeup" was removed in Syncthing v1.21.0 [1]. Thus,
remove it from the Docs too, as it is no longer functional and may
confuse new users [2].

[1] https://github.com/syncthing/syncthing/issues/8448
[2] https://github.com/syncthing/syncthing-android/issues/1961

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>