### PR TITLE
Make it clear that there is no option to restrict only to LAN

### DIFF
--- a/users/guilisten.rst
+++ b/users/guilisten.rst
@@ -16,6 +16,9 @@ also set a username and a strong password for authentication and check the
 option to use HTTPS. You are otherwise, potentially, opening up your
 Syncthing installation for the world.
 
+Those are the only two options available, for restricting GUI to only LAN
+another alternative is required (Firewall).
+
 Port Numbers
 ------------
 


### PR DESCRIPTION
I assume many ppl will want to make sure Synchthing is restricted only to LAN. I assume the first attempt would be to set a specific IP in the config, but it is not possible, and will never be:
https://forum.syncthing.net/t/limit-access-to-web-gui/12700/7

I think adding this comment will save some time for other users.