### PR TITLE
building: Fix cd command on Windows

### DIFF
--- a/dev/building.rst
+++ b/dev/building.rst
@@ -79,7 +79,7 @@ Building (Windows)
 
     # Pick a place for your Syncthing source.
     > md "%USERPROFILE%\dev"
-    > cd "%USERPROFILE%\dev"
+    > cd /D "%USERPROFILE%\dev"
 
     # Grab the code.
     > git clone https://github.com/syncthing/syncthing.git

--- a/dev/building.rst
+++ b/dev/building.rst
@@ -79,7 +79,7 @@ Building (Windows)
 
     # Pick a place for your Syncthing source.
     > md "%USERPROFILE%\dev"
-    > cd /D "%USERPROFILE%\dev"
+    > cd /d "%USERPROFILE%\dev"
 
     # Grab the code.
     > git clone https://github.com/syncthing/syncthing.git


### PR DESCRIPTION
`/d` is required if you are on a different drive.