### PR TITLE
correctly describe how to use unix sockets for gui

### DIFF
--- a/users/guilisten.rst
+++ b/users/guilisten.rst
@@ -16,6 +16,9 @@ also set a username and a strong password for authentication and check the
 option to use HTTPS. You are otherwise, potentially, opening up your
 Syncthing installation for the world.
 
+Unix sockets are supported by specifying an absolute path
+(``/run/syncthing/syncthing.socket``).
+
 Port Numbers
 ------------
 

--- a/users/syncthing.rst
+++ b/users/syncthing.rst
@@ -88,11 +88,11 @@ Options
 .. cmdoption:: --gui-address=<address>
 
     Override GUI listen address. Set this to an address (``0.0.0.0:8384``)
-    or a url (``http://0.0.0.0:8384``). supported schemes are ``http`` for
-    plain http, ``https`` for http over tls, ``unix`` for plain unix sockets
-    or ``unixs`` for tls over unix sockets. A unix socket could look like this:
-    ``unix:///run/ syncthing/syncthing.socket`` (notice the three slashes: two
-    as part of the url structure, one to specify an absolute path).
+    or a URL (``http://0.0.0.0:8384``). Supported schemes are ``http`` for
+    plain HTTP, ``https`` for HTTP over TLS, ``unix`` for plain Unix sockets
+    or ``unixs`` for TLS over Unix sockets. A Unix socket could look like this:
+    ``unix:///run/syncthing/syncthing.socket`` (notice the three slashes: two
+    as part of the URL structure, one to specify an absolute path).
 
 .. cmdoption:: --gui-apikey=<string>
 

--- a/users/syncthing.rst
+++ b/users/syncthing.rst
@@ -88,7 +88,11 @@ Options
 .. cmdoption:: --gui-address=<address>
 
     Override GUI listen address. Set this to an address (``0.0.0.0:8384``)
-    or file path (``/var/run/st.sock``, for UNIX sockets).
+    or a url (``http://0.0.0.0:8384``). supported schemes are ``http`` for
+    plain http, ``https`` for http over tls, ``unix`` for plain unix sockets
+    or ``unixs`` for tls over unix sockets. A unix socket could look like this:
+    ``unix:///run/ syncthing/syncthing.socket`` (notice the three slashes: two
+    as part of the url structure, one to specify an absolute path).
 
 .. cmdoption:: --gui-apikey=<string>
 


### PR DESCRIPTION
[the docs for `--gui-address`](https://docs.syncthing.net/users/syncthing.html#cmdoption-gui-address) incorrectly state that if a file path is given, a unix socket at that location will be used.

syncthing supports serving the gui and api over a unix socket. this can be configured via an cli or environment override. this commit corrects the documentation on this to match the way that syncthing behaves.

the gui-address cli option needs an url like "unix://<path>" to listen on unix sockets. if an (absolute) path is specified, the cli override is ignored and the gui.address from the config file is used. I think this was done because syncthing supports https (http over tls) over unix, and there needed to be a way to enable that. in the config file there is an attribute `tls` on the `gui` element. on the cli this is encoded in the url scheme: "unixs" and "https" for tls, "unix" and "http" for plain listeners.