### PR TITLE
users: Explain that GUI listen address is no firewall replacement

### DIFF
--- a/users/faq-parts/usage.rst
+++ b/users/faq-parts/usage.rst
@@ -122,11 +122,10 @@ character is used as a path separator.
 How do I access the web GUI from another computer?
 --------------------------------------------------
 
-The default listening address is 127.0.0.1:8384, so you can only access the
-GUI from the same machine. This is for security reasons. To access the web 
-GUI from another computer, change the ``GUI listen address`` through the web
-UI from ``127.0.0.1:8384`` to
-``0.0.0.0:8384`` or change the config.xml:
+The default listening address is 127.0.0.1:8384, so you can only access the GUI
+from the same machine.  This is for security reasons.  To access it from another
+computer, change the ``GUI listen address`` option in the web GUI from
+``127.0.0.1:8384`` to ``0.0.0.0:8384``, or change the ``config.xml``:
 
 .. code-block:: xml
 
@@ -137,7 +136,7 @@ to
 
 .. code-block:: xml
 
-    <gui enabled="true" tls="false">
+    <gui enabled="true" tls="true">
       <address>0.0.0.0:8384</address>
 
 Then the GUI is accessible from everywhere.  There is no filtering based on
@@ -145,31 +144,25 @@ e.g. source address (use a firewall for that).  You should set a password and
 enable HTTPS with this configuration.  You can do this from inside the GUI.
 
 If both your computers are Unix-like (Linux, Mac, etc.) you can also leave the
-GUI settings at default and use an ssh port forward to access it. For
-example,
+GUI settings at default and use an SSH port forward to access it.  For example,
 
 .. code-block:: bash
 
     $ ssh -L 9090:127.0.0.1:8384 user@othercomputer.example.com
 
-will log you into othercomputer.example.com, and present the *remote*
+will log you into ``othercomputer.example.com``, and present the *remote*
 Syncthing GUI on http://localhost:9090 on your *local* computer.
 
-If you only want to access the remote gui and don't want the terminal
-session, use this example,
+If you only want to access the remote GUI and don't want the terminal session,
+use this example:
 
 .. code-block:: bash
 
     $ ssh -N -L 9090:127.0.0.1:8384 user@othercomputer.example.com
 
-If only your remote computer is Unix-like,
-you can still access it with ssh from Windows.
-
-Under Windows 10 or later (64-bit only) you can use the same ssh command
-if you install the `Windows Subsystem for Linux <https://docs.microsoft.com/windows/wsl/install>`__.
-
-Another Windows way to run ssh is to install `gow (Gnu On Windows) <https://github.com/bmatzelle/gow>`__. The easiest way to install gow is with the `chocolatey <https://chocolatey.org/>`__ package manager.
-
+If only your remote computer is Unix-like, you can still access it with SSH from
+Windows.  Under Windows 10 or later you can use the same ``ssh`` command if you
+`install the OpenSSH Client <https://learn.microsoft.com/windows-server/administration/openssh/openssh_install_firstuse>`__.
 
 I don't like the GUI or the theme. Can it be changed?
 -----------------------------------------------------

--- a/users/faq-parts/usage.rst
+++ b/users/faq-parts/usage.rst
@@ -140,8 +140,9 @@ to
     <gui enabled="true" tls="false">
       <address>0.0.0.0:8384</address>
 
-Then the GUI is accessible from everywhere. You should set a password and
-enable HTTPS with this configuration. You can do this from inside the GUI.
+Then the GUI is accessible from everywhere.  There is no filtering based on
+e.g. source address (use a firewall for that).  You should set a password and
+enable HTTPS with this configuration.  You can do this from inside the GUI.
 
 If both your computers are Unix-like (Linux, Mac, etc.) you can also leave the
 GUI settings at default and use an ssh port forward to access it. For

--- a/users/guilisten.rst
+++ b/users/guilisten.rst
@@ -16,6 +16,13 @@ also set a username and a strong password for authentication and check the
 option to use HTTPS. You are otherwise, potentially, opening up your
 Syncthing installation for the world.
 
+Note that specifying your computer's LAN address (e.g. ``192.168.0.123:8384``)
+will **NOT** restrict access to only devices on your local network!  Connections
+with that address *as destination* will then be accepted, regardless of their
+origin.  Proper network configuration and security (especially a firewall) is
+required to enforce such filtering, as it cannot be done reliably by Syncthing
+itself.
+
 Unix sockets are supported by specifying an absolute path
 (``/run/syncthing/syncthing.socket``).
 


### PR DESCRIPTION
Building upon the suggestions in #818, incorporate an additional note that the GUI listen address setting cannot be used to restrict GUI access to only local network nodes.  Fix some styling along the way and point to OpenSSH for Windows instead of the more complicated alternatives.