### PR TITLE
users: Clarify .stignore is only read from the folder root

### DIFF
--- a/users/ignoring.rst
+++ b/users/ignoring.rst
@@ -16,11 +16,12 @@ Description
 -----------
 
 If some files should not be synchronized to (or from) other devices, a file called
-``.stignore`` can be created containing file patterns to ignore. The
-``.stignore`` file must be placed in the root of the synced folder. The
-``.stignore`` file itself will never be synced to other devices, although it can
-``#include`` files that *are* synchronized between devices. All patterns are
-relative to the synced folder root.
+``.stignore`` can be created containing file patterns to ignore.
+The ``.stignore`` file must be placed in the root of the synced folder
+(files in other localtions are not applied).
+The ``.stignore`` file itself will never be synced to other devices,
+although it can ``#include`` files that *are* synchronized between devices.
+All patterns are relative to the synced folder root.
 The contents of the ``.stignore`` file must be UTF-8 encoded.
 
 .. note::

--- a/users/ignoring.rst
+++ b/users/ignoring.rst
@@ -16,12 +16,13 @@ Description
 -----------
 
 If some files should not be synchronized to (or from) other devices, a file called
-``.stignore`` can be created containing file patterns to ignore.
-The ``.stignore`` file must be placed in the root of the synced folder
-(files in other localtions are not applied).
-The ``.stignore`` file itself will never be synced to other devices,
-although it can ``#include`` files that *are* synchronized between devices.
-All patterns are relative to the synced folder root.
+If some files should not be synchronized to (or from) other devices, a file called
+``.stignore`` can be created containing file patterns to ignore.  The ``.stignore``
+file must be placed in the root of the synced folder (files in other locations are
+not applied).  The ``.stignore`` file itself will never be synced to other devices,
+although it can ``#include`` files that *are* synchronized between devices.  All
+patterns are relative to the synced folder root.  The contents of the ``.stignore``
+file must be UTF-8 encoded.
 The contents of the ``.stignore`` file must be UTF-8 encoded.
 
 .. note::


### PR DESCRIPTION
This is a follow up to https://forum.syncthing.net/t/is-it-correct-that-stignore-inside-a-subfolder-is-not-applied/20997

Also amended whitespacing in the .md file: as it was written, it was somewhat difficult to find the statement to edit (and also will cause multiple edits when applying the max-length best practice; splitting lines statement-wise seems to be more consistent).