### PR TITLE
status.syncthing.net uses updown.io

### DIFF
--- a/dev/infrastructure.rst
+++ b/dev/infrastructure.rst
@@ -82,6 +82,6 @@ Monitoring
 
 The infrastructure is monitored and its status is publicly accessible on the following urls:
 
-- `status.syncthing.net <https://status.syncthing.net>`__ (Apex Ping)
+- `status.syncthing.net <https://status.syncthing.net>`__ (updown.io service)
 - `monitor.syncthing.net <https://monitor.syncthing.net>`__ (Grafana)
 


### PR DESCRIPTION
Not open source, that's why service.