### PR TITLE
rest/events: Warn about future event IDs

### DIFF
--- a/rest/events-get.rst
+++ b/rest/events-get.rst
@@ -22,6 +22,11 @@ waits for new events to happen before returning. By default it times out after
 60 seconds returning an empty array. The time out duration can be customized
 with the optional parameter ``timeout=<seconds>``.
 
+.. warning::
+   Using ``since`` with a future event ID, an event ID larger than the latest
+   known one, causes server to wait until the difference between the latest
+   and requested/future is filled with a higher possibly of timeout.
+
 To receive only a limited number of events, add the ``limit=<n>`` parameter with a
 suitable value for ``n`` and only the *last* ``n`` events will be returned. This
 can be used to catch up with the latest event ID after a disconnection for

--- a/rest/events-get.rst
+++ b/rest/events-get.rst
@@ -18,14 +18,10 @@ long some events might be missed. This can be detected by noting a discontinuity
 in the event IDs.
 
 If no new events are produced since ``<lastSeenID>``, the HTTP call blocks and
-waits for new events to happen before returning. By default it times out after
-60 seconds returning an empty array. The time out duration can be customized
-with the optional parameter ``timeout=<seconds>``.
-
-.. warning::
-   Using ``since`` with a future event ID, an event ID larger than the latest
-   known one, causes server to wait until the difference between the latest
-   and requested/future is filled with a higher possibly of timeout.
+waits for new events to happen before returning. If ``<lastSeenID>`` is a
+future ID, the HTTP call blocks until such ID is reached or timeouts. By
+default it times out after 60 seconds returning an empty array. The time out
+duration can be customized with the optional parameter ``timeout=<seconds>``.
 
 To receive only a limited number of events, add the ``limit=<n>`` parameter with a
 suitable value for ``n`` and only the *last* ``n`` events will be returned. This


### PR DESCRIPTION
I'm not sure whether somebody else has fallen into this as it might be too obvious yet maybe an extra note/warning about being careful could help, especially when one would want to chunk by let's say multiples of 100 and ended up with a blocking call wondering why.