### PR TITLE
Update reverseproxy.rst - added HAProxy example

### DIFF
--- a/users/reverseproxy.rst
+++ b/users/reverseproxy.rst
@@ -82,6 +82,21 @@ Caddy v2
         }
     }
 
+HAProxy
+~~~~~~~
+
+.. code-block:: none
+
+    frontend syncthing-in
+        bind :80
+        bind :443 ssl crt /etc/ssl/ssl-certs.pem
+        http-request redirect scheme https unless { ssl_fc }
+        http-request set-header Host localhost
+        default_backend syncthing-service
+
+    backend syncthing-service
+        server syncthing 127.0.0.1:8384
+
 
 Folder Configuration
 --------------------


### PR DESCRIPTION
I added HAProxy example that I am running in my setup (TLS termination at Proxy with own certificate).
The most important part is to set the **Host** headers correctly (unless one wants to use _insecureSkipHostcheck_).