### PR TITLE
Add Steam Deck Plugin to Community Contrib.

### DIFF
--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -69,6 +69,10 @@ Linux
 - `syncthing-tray-gtk3 <https://github.com/abdeoliveira/syncthing-tray-gtk3>`_
 
   Yet another Syncthing tray icon indicator written in Ruby.
+  
+- `steamdeck-decky-syncthing  <https://github.com/theCapypara/steamdeck-decky-syncthing>`_
+
+  A Steam Deck (Decky Loader) plugin for controlling Syncthing from the Steam Big Picture / Steam Deck UI.
 
 Command Line Tools
 ------------------


### PR DESCRIPTION
I created a Steam Deck plugin to control Syncthing directly from the Steam Deck UI. This also theoretically works on any other Linux distro where Decky Loader ( https://decky.xyz/ ) can be installed.

https://github.com/theCapypara/steamdeck-decky-syncthing

This adds a link to that to the Community Contributions.