### PR TITLE
users/config: be more precise about trafficClass value

### DIFF
--- a/users/config.rst
+++ b/users/config.rst
@@ -1221,7 +1221,10 @@ The ``options`` element contains all other global configuration options.
 
 .. option:: options.trafficClass
 
-    Specify a type of service (TOS)/traffic class of outgoing packets.
+    Specify an IPv4 type of service (TOS)/IPv6 traffic class for outgoing
+    packets. To specify a differentiated services code point (DSCP) the value
+    must be bit shifted to the left by two to take the two least significant
+    ECN bits into account.
 
 .. option:: options.stunServer
     :aliases: options.stunServers


### PR DESCRIPTION
Although described, it was not obvious to me what exact value needs to be specified. To improve this, it was explicitly stated that it's about the respective [IPv4](https://en.wikipedia.org/wiki/Type_of_service) and [IPv6](https://en.wikipedia.org/wiki/IPv6_packet#Fixed_header) header fields.

Additionally, users most likely want to specify a [DSCP](https://en.wikipedia.org/wiki/Differentiated_services) value. To help in this case the required bit shift was mentioned.