### PR TITLE
Improve link to Syncthing Tray

### DIFF
--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -15,7 +15,7 @@ GUI Wrappers
 Cross-platform
 ~~~~~~~~~~~~~~
 
-- `syncthingtray <https://github.com/Martchus/syncthingtray>`__
+- `Syncthing Tray <https://martchus.github.io/syncthingtray>`__
 
 Android
 ~~~~~~~


### PR DESCRIPTION
* Use correct casing
* Point to the website which is more beginner friendly then the README on GitHub