### PR TITLE
Untrusted devices will not delete data

### DIFF
--- a/users/untrusted.rst
+++ b/users/untrusted.rst
@@ -58,6 +58,10 @@ becomes available.
         T2 -> U1 [label="Encrypted by T2"]
     }
 
+In the above scenarios, if the untrusted device U1 deletes a local copy of a
+file, this is not replicated directly to trusted hosts. Untrusted hosts might
+receive the notice, however.
+
 Similarly, it's fine to add "normal mode" synchronization between untrusted devices.
 
 .. graphviz::


### PR DESCRIPTION
Explicitly mention that untrusted devices can delete files from a synchronised folder. While this can be inferred from the current description, it's probably best to be explicitly for this kind of caveat.