### PR TITLE
chore(contrib): move syncthing-android and SyncTrayzor to old list

### DIFF
--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -20,24 +20,10 @@ Cross-platform
 Android
 ~~~~~~~
 
-- `syncthing-android <https://github.com/syncthing/syncthing-android>`_
-
-  A wrapper app for the Syncthing binary.
-
 - `Syncthing-Fork <https://github.com/catfriend1/syncthing-android>`_
 
   An alternative wrapper app for the Syncthing binary with extended
   functionality.
-
-.. _contrib-windows:
-
-Windows
-~~~~~~~
-
-- `SyncTrayzor <https://github.com/canton7/SyncTrayzor>`_
-
-  Windows host for Syncthing.  Installer, auto-start, built-in browser, tray
-  icon, and more.
 
 macOS
 ~~~~~
@@ -278,6 +264,8 @@ Older, Possibly Unmaintained
    these and you have revived the project, please update this page
    accordingly.
 
+- `syncthing-android <https://github.com/syncthing/syncthing-android>`_ (Archived on 2024-12-03)
+- `SyncTrayzor <https://github.com/canton7/SyncTrayzor>`_
 - `a-sync <https://github.com/davide-imbriaco/a-sync>`_
 - `syncthing-tray-gtk3 <https://github.com/abdeoliveira/syncthing-tray-gtk3>`_ (Archived as of 2023-12-29)
 - `Syncthing-GTK <https://github.com/syncthing-gtk/syncthing-gtk>`_ (Fork from `Kozec <https://github.com/kozec/syncthing-gtk>`_)

--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -25,6 +25,15 @@ Android
   An alternative wrapper app for the Syncthing binary with extended
   functionality.
 
+.. _contrib-windows:
+
+Windows
+~~~~~~~
+
+We currently don't have any actively updated Windows-specific GUI wrappers here.
+
+.. seealso:: :ref:`Cross-platform GUI Wrappers <contrib-all>`.
+
 macOS
 ~~~~~
 


### PR DESCRIPTION
SyncTrayzor hasn't received any commits in 4 years, and syncthing-android is officially discontinued, so add them to the old list.

Fixes #892.