### PR TITLE
chore(advanced): clarify multiple connections over relays

### DIFF
--- a/advanced/device-numconnections.rst
+++ b/advanced/device-numconnections.rst
@@ -61,4 +61,8 @@ default, TCP has better priority than QUIC, so establishing a TCP connection
 will cause existing QUIC connections to be closed. Connection priorities can
 be configured.
 
-Multiple connections cannot be established over relays.
+When connected via a relay, only one connection is normally established.
+However, with some lucky timing, e.g. when attempting to reconnect after losing
+a connection, it is also possible to establish one relay connection in each
+direction, if the two devices are listening on different relays. In such a case,
+the GUI will show `1 + 1` connections.


### PR DESCRIPTION
chore(advanced): clarify multiple connections over relays

Clarify that it is possible to establish two connections when each
device uses a different relay.

Ref: https://forum.syncthing.net/t/multiple-connections-established-over-a-relay-but-docs-claim-its-impossible/20975

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>