### PR TITLE
chore(contrib): add sm2 and move munin-syncthing to unmaintained

### DIFF
--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -253,7 +253,8 @@ Monitoring
 
 - `sm² <https://github.com/nware-lab/sm2>`_
 
-  A docker container made to "Monitor multiple syncthing instances while using as little diskspace & memory while doing it." 
+  A Docker container made to "monitor multiple Syncthing instances while using
+  as little diskspace & memory while doing it."
 
 Resolving conflicts
 ~~~~~~~~~~~~~~~~~~~

--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -251,7 +251,9 @@ Configuration management
 Monitoring
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-- `munin-syncthing <https://gitlab.com/daftaupe/munin-syncthing>`_
+- `sm² <https://github.com/nware-lab/sm2>`_
+
+  A docker container made to "Monitor multiple syncthing instances while using as little diskspace & memory while doing it." 
 
 Resolving conflicts
 ~~~~~~~~~~~~~~~~~~~
@@ -296,3 +298,4 @@ Older, Possibly Unmaintained
 -  https://github.com/nhojb/SyncthingBar
 -  https://github.com/jastBytes/SyncthingTray
 -  https://github.com/alex2108/syncthing-tray
+- `munin-syncthing <https://gitlab.com/daftaupe/munin-syncthing>`_

--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -251,7 +251,7 @@ Configuration management
 Monitoring
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-- `sm² <https://github.com/nware-lab/sm2>`_
+- `sm² (Syncthing Multi Server Monitor) <https://github.com/nware-lab/sm2>`_
 
   A Docker container made to "monitor multiple Syncthing instances while using
   as little diskspace & memory while doing it."


### PR DESCRIPTION
Add sm2 to the monitoring projects.
Move munin-syncthing to the Older, Possibly Unmaintained projects (last updated 7 years ago)

I feels a bit wierd to move somebody else's project down to the "old" list.
But the munin project itself also seems inactive. last release end off 2023 and their demo & plugin gallery seem down.