### PR TITLE
feat(faq): add information on setting network to private in Windows

### DIFF
--- a/users/faq-parts/troubleshooting.rst
+++ b/users/faq-parts/troubleshooting.rst
@@ -196,7 +196,7 @@ will be merged with files from remote devices.
 Also see the :ref:`marker FAQ <marker-faq>` for more information about the folder marker.
 
 Why do my Windows computers always connect through a relay?
---------------------------------------------------------------
+-----------------------------------------------------------
 
 When connecting to a new network, Windows by default sets its profile to
 "Public". While being more secure, this setting also prevents applications like

--- a/users/faq-parts/troubleshooting.rst
+++ b/users/faq-parts/troubleshooting.rst
@@ -194,3 +194,13 @@ it will also reset the database state of this folder. It will be considered a "n
 will be merged with files from remote devices.
 
 Also see the :ref:`marker FAQ <marker-faq>` for more information about the folder marker.
+
+Why do my Windows computers always connect through a relay?
+--------------------------------------------------------------
+
+When connecting to a new network, Windows by default sets its profile to
+"Public". While being more secure, this setting also prevents applications like
+Syncthing from being able to establish direct connections with the device in
+question, forcing it to connect through a relay. If you would rather connect
+your devices directly, please follow `the official Microsoft instructions on how
+to change the network profile to "Private" <https://support.microsoft.com/windows/essential-network-settings-and-tasks-in-windows-f21a9bbc-c582-55cd-35e0-73431160a1b9#bkmk_network_profile>`__.

--- a/users/faq-parts/troubleshooting.rst
+++ b/users/faq-parts/troubleshooting.rst
@@ -199,8 +199,8 @@ Why do my Windows computers always connect through a relay?
 -----------------------------------------------------------
 
 When connecting to a new network, Windows by default sets its profile to
-"Public". While being more secure, this setting also prevents applications like
-Syncthing from being able to establish direct connections with the device in
-question, forcing it to connect through a relay. If you would rather connect
+"Public". While being more secure, this setting commonly prevents applications
+like Syncthing from being able to establish direct connections with the device
+in question, forcing it to connect through a relay. If you would rather connect
 your devices directly, please follow `the official Microsoft instructions on how
 to change the network profile to "Private" <https://support.microsoft.com/windows/essential-network-settings-and-tasks-in-windows-f21a9bbc-c582-55cd-35e0-73431160a1b9#bkmk_network_profile>`__.


### PR DESCRIPTION
feat(faq): add information on setting network to private in Windows

The issue of Windows devices being unable to connect directly with each
other comes up often on the forum. One of them main reasons for the
problem is Windows setting the default network profile to "Public"
instead of "Private", which prevents direct connections.

Instead of repeating the same instructions on how to change the network
profile to "Private" over and over, add a new entry to the FAQ, which we
can then use as a reference when needed.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>