### PR TITLE
chore(specs): update BEP regarding multiple cluster config messages

### DIFF
--- a/specs/bep-v1.rst
+++ b/specs/bep-v1.rst
@@ -221,8 +221,9 @@ Cluster Config
 This informational message provides information about the cluster
 configuration as it pertains to the current connection. A Cluster Config
 message MUST be the first post authentication message sent on a BEP
-connection. Additional Cluster Config messages MUST NOT be sent after the
-initial exchange.
+connection. Additional Cluster Config messages MAY be sent after the initial
+exchange to change the connection in place with the update configuration. If an
+implementation does not support that, it SHOULD close the connection.
 
 Protocol Buffer Schema
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Syncthing is already sending multiple cluster configs for a long time - reflect that in the spec. I added the SHOULD part about closing the connection if multiple CCs aren't supported with the intention to keep the spec change backwards compatible and have reasonable behaviour, which this imo provides.

I noticed we don't specify what the compatibility expectations can be on the BEP - I just assumed a broad, rather generous variant, i.e. that the use-case outlined in the intro continuous to function between to clients implementing the spec before and after a change. Of course in reality only the connection to syncthing's compatibility guarantee really matters, i.e. that two syncthing versions before and after keep syncing fine, as there's no other significantly adopted BEP implementations - I just still have a soft spot for the mere possibility of independent implementations :)