### PR TITLE
chore(contrib): update for Community -> Extra merge on Arch Linux

### DIFF
--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -136,7 +136,7 @@ Unofficial `RPM repo of Syncthing <https://copr.fedorainfracloud.org/coprs/dafta
 ArchLinux
 ~~~~~~~~~
 
-- Official Community Repository: `syncthing <https://archlinux.org/packages/?name=syncthing>`__
+- Official Extra Repository: `syncthing <https://archlinux.org/packages/?name=syncthing>`__
 
 - Arch User Repository: `syncthingtray <https://aur.archlinux.org/packages/syncthingtray>`__
 


### PR DESCRIPTION
The Arch Linux `syncthing` package is now in the Extra repository instead of Community, because they have been
[merged](https://rfc.archlinux.page/0014-merge-package-repos).