### PR TITLE
chore(issues): remove mentions of "Planned" and "Unplanned" milestones

### DIFF
--- a/dev/issues.rst
+++ b/dev/issues.rst
@@ -80,22 +80,6 @@ Each released version gets a milestone. Issues that are resolved and will be
 released as that version get added to the milestone. The release notes are
 based on the issues present in the milestone.
 
-In addition to version specific milestones there are two generic ones:
-
-Planned
-    This issue is being worked on, or will soon be worked on, by someone in
-    the core team. Expect action on it within the next few days, weeks or
-    months.
-
-Unplanned (Contributions Welcome)
-    This issue is not being worked on by the core team, and we don't plan on
-    doing so in the foreseeable future. We still consider it a valid issue
-    and welcome contributions towards resolving it.
-
-Issues lacking a milestone are currently undecided. In practice this is
-similar to Unplanned in that probably no-one is working on it, but we are
-still considering it and it may end up Planned or closed instead.
-
 Assignee
 --------
 


### PR DESCRIPTION
These milestones have been deleted.

Also removes mentions of the "core" team, which has been replaced by (renamed to?) the "contributors" team.