### PR TITLE
fix(contrib): match "Arch Linux" title length with underline length

### DIFF
--- a/users/contrib.rst
+++ b/users/contrib.rst
@@ -139,7 +139,7 @@ For Fedora Syncthing is now in the official repo : https://src.fedoraproject.org
 Unofficial `RPM repo of Syncthing <https://copr.fedorainfracloud.org/coprs/daftaupe/syncthing/>`_ (`sources <https://gitlab.com/daftaupe/syncthing-rpm>`_)
 
 Arch Linux
-~~~~~~~~~
+~~~~~~~~~~
 
 - Official Extra Repository: `syncthing <https://archlinux.org/packages/?name=syncthing>`__
 


### PR DESCRIPTION
Fixes a regression introduced in #942.

```
users/contrib.rst:142: WARNING: Title underline too short.
```