### PR TITLE
chore(tuning): clarify units, update defaults, fix typo

### DIFF
--- a/users/tuning.rst
+++ b/users/tuning.rst
@@ -29,7 +29,7 @@ is on an SSD. First some general options:
     concurrently, taking into account the inherent concurrency of the
     underlying storage system. If two folders are on the same underlying
     spinning disk, syncing them concurrently will be a strict loss of
-    performance. If the underlying storage is a large array of disk,
+    performance. If the underlying storage is a large array of disks,
     then syncing many folders concurrently may be beneficial.
 
 - :opt:`maxConcurrentIncomingRequestKiB`
@@ -37,8 +37,8 @@ is on an SSD. First some general options:
     disk and transmitted over the network) concurrently at any given
     time. This is a global limiter, not per folder. If you have a lot of
     folders and/or a lot of devices and memory to spare you may want to
-    increase this value. The default is 256 MiB, consider values of 1024
-    MiB or more.
+    increase this value. The default is 262144 KiB (256 MiB), consider values
+    of 1048576 KiB (1024 MiB) or more.
 
 These options are folder specific and should be set on each folder:
 
@@ -64,7 +64,7 @@ These options are folder specific and should be set on each folder:
 - :opt:`pullerMaxPendingKiB`
     The maximum amount of data to have outstanding requests for at any given
     time. Higher values may improve performance, especially if the network
-    or I/O latency is high. The default is 32 MiB.
+    or I/O latency is high. The default is 32768 KiB (32 MiB).
 
 - :opt:`scanProgressIntervalS`
     Providing the GUI with scan progress updates is not very expensive, but
@@ -76,7 +76,7 @@ These options are folder specific and should be set on each folder:
     given time to avoid overloading the I/O system. If you increased
     copiers, outstanding network requests, or other settings that increase
     the number of concurrent writes, you may need to increase this value.
-    The default is 2.
+    The default is 16.
 
 - :opt:`disableFsync`
     Syncthing calls ``fsync()`` on files and directories after syncing them
@@ -141,8 +141,8 @@ General options:
     Set to 1 to sync folders sequentially, reducing the peak memory usage.
 
 - :opt:`maxConcurrentIncomingRequestKiB`
-    Set to 32 MiB to reduce the amount of memory used for buffering
-    responses to incoming requests.
+    Set to 32768 KiB (32 MiB) to reduce the amount of memory used for
+    buffering responses to incoming requests.
 
 Folders options:
 
@@ -155,8 +155,8 @@ Folders options:
     folder, reducing peak memory usage.
 
 - :opt:`pullerMaxPendingKiB`
-    Set to 16 MiB to reduce the amount of memory used for buffering
-    while syncing.
+    Set to 16384 KiB (16 MiB) to reduce the amount of memory used for
+    buffering while syncing.
 
 - :opt:`scanProgressIntervalS`
     Set to -1 to disable scan progress updates. Keeping track of scan progress


### PR DESCRIPTION
chore(tuning): clarify units, update defaults, fix typo

This is a set of small fixes to the Configuration Tuning page:

1. Currently, recommendations use values calculated in MiB even though
   the user is supposed to input them in KiB. To avoid confusion, put
   the KiB value first with the MiB one next to it in brackets for easy
   understanding.

2. Update the default number of maxConcurrentWrites from 2 to 16. This
   was changed with the upgrade to Syncthing v2.

3. Fix a minor typo in the maxFolderConcurrency explanation.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>