### PR TITLE
docs(config): update section titles and enhance overview for clarity

### DIFF
--- a/users/config.rst
+++ b/users/config.rst
@@ -1,10 +1,18 @@
 .. default-domain:: stconf
 
+
 Syncthing Configuration
 =======================
 
-Synopsis
+Overview
 --------
+
+This page covers how to configure Syncthing for file synchronization, including device setup, folder configuration, connection settings, and various configuration methods through the web GUI, command-line, or direct file editing.
+
+Configuration File Locations
+---------------------------
+
+The default configuration and database directory locations are:
 
 ::
 


### PR DESCRIPTION
Improved the configuration documentation by clarifying section titles and adding an overview for new users. This should make the page easier to understand, which is especially important since the docs are also used as web documentation.

The previous manpage-style formatting felt unnecessarily technical and less approachable for newcomers. The new 'Overview' section adds helpful context without removing any details.