### PR TITLE
fix(autostart): remove --no-console from Windows instructions

### DIFF
--- a/users/autostart.rst
+++ b/users/autostart.rst
@@ -90,7 +90,7 @@ https://docs.microsoft.com/windows/win32/taskschd.
    #. Click "New...".
    #. Enter the path to ``syncthing.exe`` in "Program/script:" (for
       example ``C:\syncthing\syncthing.exe``).
-   #. Enter ``--no-console --no-browser`` in "Add arguments (optional):"
+   #. Enter ``--no-browser`` in "Add arguments (optional):"
    #. Click "OK".
 
    |Windows Task Scheduler Actions Screenshot|
@@ -163,8 +163,8 @@ opening on start, is relatively easy.
    |Windows Startup Folder New Shortcut Screenshot|
 
 #. Enter the path to ``syncthing.exe`` in "Type the location of the item:"
-   followed by ``--no-console --no-browser`` (for example ``C:\syncthing\syncthing.exe
-   --no-console --no-browser``).
+   into the command ``conhost.exe --headless syncthing.exe --no-browser``
+   (for example ``conhost.exe --headless C:\syncthing\syncthing.exe --no-browser``).
 
    |Windows Startup Folder Create Shortcut Screenshot|
 
@@ -175,6 +175,13 @@ Syncthing will now automatically start the next time you log on to your
 user account in Windows. No console or browser window will pop-up, but
 you can still access the interface by opening http://localhost:8384 in
 a Web browser.
+
+.. note::
+
+   It used to be possible to start Syncthing with its console window hidden by
+   using the `--no-console` option. However, this method no longer works in
+   newer versions of Windows that have Windows Terminal set as their default
+   shell. For this reason, using `--no-console` is no longer recommended here.
 
 .. _autostart-windows-tools:
 


### PR DESCRIPTION
fix(autostart): remove --no-console from Windows instructions

With the advent of Windows Terminal and it being the default shell both
in newer releases of Windows 10, and in Windows 11, the `--no-console`
command line switch no longer works. For this reason, remove it from the
commands listed in the autostart instructions. When it comes to the Task
Scheduler part, it has never actually been needed anyway, and in the
Startup folder instructions, it can be worked around by using the native
`conhost.exe --headless` method.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>