### PR TITLE
chore(autostart): add note about allowing access in Windows Firewall

### DIFF
--- a/users/autostart.rst
+++ b/users/autostart.rst
@@ -105,9 +105,9 @@ https://docs.microsoft.com/windows/win32/taskschd.
 
 .. note::
 
-   You should start Syncthing interactively (i.e. without relying on Task
+   You should start Syncthing interactively (i.e. without relying on the Task
    Scheduler) at least once in order to trigger a Windows Firewall pop-up,
-   which will ask you you to allow Syncthing to access your network. This is
+   which will ask you to allow Syncthing to access your network. This is
    required, e.g. if you want Syncthing to establish direct connections inside
    the given network, and also if you intend to access the web GUI remotely.
 

--- a/users/autostart.rst
+++ b/users/autostart.rst
@@ -103,6 +103,14 @@ https://docs.microsoft.com/windows/win32/taskschd.
 
    |Windows Task Scheduler Settings Screenshot|
 
+.. note::
+
+   You should start Syncthing interactively (i.e. without relying on Task
+   Scheduler) at least once in order to trigger a Windows Firewall pop-up,
+   which will ask you you to allow Syncthing to access your network. This is
+   required, e.g. if you want Syncthing to establish direct connections inside
+   the given network, and also if you intend to access the web GUI remotely.
+
 Additional configuration in Task Scheduler
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
chore(autostart): add note about allowing access in Windows Firewall

Currently, we always recommend to "Run whether user is logged on or not"
when using the Task Scheduler to start Syncthing automatically. The
problem is that this makes Syncthing run completely hidden in background
which prevents Windows Firewall from prompting the user to allow
Syncthing to access the network. Therefore, add a note explaining that
the user should run Syncthing interactively at least once, which will
allow the Windows Firewall pop-up to be displayed on the screen.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>