### PR TITLE
fix(syncthing): add note about --no-console requiring Command Prompt

### DIFF
--- a/users/syncthing.rst
+++ b/users/syncthing.rst
@@ -174,7 +174,8 @@ Serve options
 
 .. cmdoption:: --no-console
 
-    Hide the console window. (On Windows only)
+    Hide the console window. (On Windows, and only if the OS default shell is
+    set to Command Prompt)
 
 .. cmdoption:: --no-port-probing
 


### PR DESCRIPTION
fix(syncthing): add note about --no-console requiring Command Prompt

Clarify that the `--no-console` option only works when the Command
Prompt is set to be the default Windows shell. On the other hand, the
option does nothing when the default shell is set to Windows Terminal.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>