### PR TITLE
Fix maxConcurrentWrites in docs

### DIFF
--- a/users/config.rst
+++ b/users/config.rst
@@ -124,7 +124,7 @@ The following shows an example of a default configuration file (IDs will differ)
             <markerName>.stfolder</markerName>
             <copyOwnershipFromParent>false</copyOwnershipFromParent>
             <modTimeWindowS>0</modTimeWindowS>
-            <maxConcurrentWrites>2</maxConcurrentWrites>
+            <maxConcurrentWrites>16</maxConcurrentWrites>
             <disableFsync>false</disableFsync>
             <blockPullOrder>standard</blockPullOrder>
             <copyRangeMethod>standard</copyRangeMethod>
@@ -226,7 +226,7 @@ The following shows an example of a default configuration file (IDs will differ)
                 <markerName>.stfolder</markerName>
                 <copyOwnershipFromParent>false</copyOwnershipFromParent>
                 <modTimeWindowS>0</modTimeWindowS>
-                <maxConcurrentWrites>2</maxConcurrentWrites>
+                <maxConcurrentWrites>16</maxConcurrentWrites>
                 <disableFsync>false</disableFsync>
                 <blockPullOrder>standard</blockPullOrder>
                 <copyRangeMethod>standard</copyRangeMethod>
@@ -312,7 +312,7 @@ Folder Element
         <markerName>.stfolder</markerName>
         <copyOwnershipFromParent>false</copyOwnershipFromParent>
         <modTimeWindowS>0</modTimeWindowS>
-        <maxConcurrentWrites>2</maxConcurrentWrites>
+        <maxConcurrentWrites>16</maxConcurrentWrites>
         <disableFsync>false</disableFsync>
         <blockPullOrder>standard</blockPullOrder>
         <copyRangeMethod>standard</copyRangeMethod>
@@ -540,7 +540,7 @@ The following child elements may exist:
 .. option:: folder.maxConcurrentWrites
 
     Maximum number of concurrent write operations while syncing. Increasing this might increase or
-    decrease disk performance, depending on the underlying storage. Default is ``2``.
+    decrease disk performance, depending on the underlying storage. Default is ``16``.
 
 .. option:: folder.disableFsync
 
@@ -1371,7 +1371,7 @@ Defaults Element
             <markerName>.stfolder</markerName>
             <copyOwnershipFromParent>false</copyOwnershipFromParent>
             <modTimeWindowS>0</modTimeWindowS>
-            <maxConcurrentWrites>2</maxConcurrentWrites>
+            <maxConcurrentWrites>16</maxConcurrentWrites>
             <disableFsync>false</disableFsync>
             <blockPullOrder>standard</blockPullOrder>
             <copyRangeMethod>standard</copyRangeMethod>


### PR DESCRIPTION
As of v2.0.7 and since https://github.com/syncthing/syncthing/commit/88c307b65be76690e317b5442a6ba0721a98cfbc in https://github.com/syncthing/syncthing/pull/10200, `maxConcurrentWrites` been bumped to 16 as tuning docs suggest.