### PR TITLE
chore(all): fix various RST file formatting errors

### DIFF
--- a/includes/env-vars.rst
+++ b/includes/env-vars.rst
@@ -6,32 +6,55 @@ STTRACE
     ``api:WARN,beacon:ERR``, potentially overriding a global ``--log-level``
     adjustment.
 
-     The valid facility strings are listed below; additionally, ``syncthing
-     serve --help`` always outputs the most up-to-date list.
+    The valid facility strings are listed below; additionally, ``syncthing
+    serve --help`` always outputs the most up-to-date list.
 
-        api             - REST API
-        beacon          - Multicast and broadcast discovery
-        config          - Configuration loading and saving
-        connections     - Connection handling
-        db/sqlite       - SQLite database
-        dialer          - Dialing connections
-        discover        - Remote device discovery
-        events          - Event generation and logging
-        fs              - Filesystem access
-        main            - Main package
-        model           - The root hub
-        nat             - NAT discovery and port mapping
-        pmp             - NAT-PMP discovery and port mapping
-        protocol        - The BEP protocol
-        relay/client    - Relay client
-        scanner         - File change detection and hashing
-        stun            - STUN functionality
-        syncthing       - Main run facility
-        upgrade         - Binary upgrades
-        upnp            - UPnP discovery and port mapping
-        ur              - Usage reporting
-        versioner       - File versioning
-        watchaggregator - Filesystem event watcher
+    api
+        REST API
+    beacon
+        Multicast and broadcast discovery
+    config
+        Configuration loading and saving
+    connections
+        Connection handling
+    db/sqlite
+        SQLite database
+    dialer
+        Dialing connections
+    discover
+        Remote device discovery
+    events
+        Event generation and logging
+    fs
+        Filesystem access
+    main
+        Main package
+    model
+        The root hub
+    nat
+        NAT discovery and port mapping
+    pmp
+        NAT-PMP discovery and port mapping
+    protocol
+        The BEP protocol
+    relay/client
+        Relay client
+    scanner
+        File change detection and hashing
+    stun
+        STUN functionality
+    syncthing
+        Main run facility
+    upgrade
+        Binary upgrades
+    upnp
+        UPnP discovery and port mapping
+    ur
+        Usage reporting
+    versioner
+        File versioning
+    watchaggregator
+        Filesystem event watcher
 
 STLOCKTHRESHOLD
     Used for debugging internal deadlocks; sets debug sensitivity. Use only

--- a/specs/relay-v1.rst
+++ b/specs/relay-v1.rst
@@ -132,6 +132,7 @@ messages:
 2. ResponseAlreadyConnected - Session is full (both sides already connected)
 3. ResponseSuccess - You have successfully joined the session
 4. RelayFull - Relay limits are too strict for you to be able to join the session.
+
 The relay immediately terminates the connection after sending this.
 
 After the successful response, all the bytes written and received will be

--- a/users/config.rst
+++ b/users/config.rst
@@ -10,7 +10,7 @@ Overview
 This page covers how to configure Syncthing for file synchronization, including device setup, folder configuration, connection settings, and various configuration methods through the web GUI, command-line, or direct file editing.
 
 Configuration File Locations
----------------------------
+----------------------------
 
 The default configuration and database directory locations are:
 


### PR DESCRIPTION
chore(all): fix various RST file formatting errors

Fix various RST formatting errors as reported by Sphinx when building
HTML for the Docs.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>