### PR TITLE
fix(specs): fix relay formatting errors

### DIFF
--- a/specs/relay-v1.rst
+++ b/specs/relay-v1.rst
@@ -132,7 +132,7 @@ messages:
 2. ResponseAlreadyConnected - Session is full (both sides already connected)
 3. ResponseSuccess - You have successfully joined the session
 4. RelayFull - Relay limits are too strict for you to be able to join the session.
-               The relay immediately terminates the connection after sending this.
+   The relay immediately terminates the connection after sending this.
 
 After the successful response, all the bytes written and received will be
 relayed between the two devices in the session directly.


### PR DESCRIPTION
First error (introduced in #961) fixed is where the "The relay immediately terminates the connection after sending this." is not included in the enumeration above. That statement only applies in the case of RelayFull.

Second error is that the response codes right after the "Protocol defined responses" comment are actually considered a part of the comment because the indentation level is 1 higher, and therefore won't be displayed.

According to https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#comments:

> Arbitrary indented text may be used on the lines following the explicit markup start:
> ```
> .. This is a comment
> ..
>    _so: is this!
> ```