### PR TITLE
fix(includes): use correct ERROR log level for STTRACE example

### DIFF
--- a/includes/env-vars.rst
+++ b/includes/env-vars.rst
@@ -3,7 +3,7 @@ STTRACE
     generally mapping to a Go package. Enter a comma-separated string of
     facilities to trace: ``api,beacon``. Optionally, a log level can be
     given per facility to specify something other than DEBUG:
-    ``api:WARN,beacon:ERR``, potentially overriding a global ``--log-level``
+    ``api:WARN,beacon:ERROR``, potentially overriding a global ``--log-level``
     adjustment.
 
     The valid facility strings are listed below; additionally, ``syncthing


### PR DESCRIPTION
Log level ERR doesn't exist and you will get an error if you try to set it in STTRACE. For example:

```
2025-11-23 13:03:24 WRN Bad log level requested in STTRACE (pkg=beacon level=ERR error="slog: level string \"ERR\": unknown name" log.pkg=slogutil)
```

ERROR is correct and won't give you this error.