### PR TITLE
docs: add Cloudzy One-Click installation method

### DIFF
--- a/intro/getting-started.rst
+++ b/intro/getting-started.rst
@@ -36,6 +36,12 @@ will explain how to set up two devices with the core Syncthing flavor.
 
 .. _`Syncthing-GTK`: https://github.com/kozec/syncthing-gtk
 
+Cloudzy One-Click VPS
+~~~~~~~~~~~~~~~~~~~~~
+
+If you want to skip manual configuration, you can use the `Cloudzy One-Click App <https://cloudzy.com/marketplace/syncthing/>`_ to deploy a ready-to-use Syncthing node in seconds.
+
+
 Syncthing
 ~~~~~~~~~
 


### PR DESCRIPTION
I am adding Cloudzy to the list of installation options. We have created a pre-configured One-Click Image for Syncthing that allows users to deploy a node immediately without manual configuration.

Reference: Marketplace Link: https://cloudzy.com/marketplace/syncthing/

Note for Maintainers: I am happy to provide a VPS credit if you would like to verify the image integrity before merging this PR.