### PR TITLE
feat(proxy): add HTTP/HTTPS proxy support via all_proxy

### DIFF
--- a/users/proxying.rst
+++ b/users/proxying.rst
@@ -5,11 +5,15 @@ Using Proxies
 
 .. versionadded:: 0.12.0
 
-Syncthing can run behind a SOCKS5 proxy. This enables use behind some corporate
+Syncthing can run behind a SOCKS5, HTTP, or HTTPS proxy. This enables use behind some corporate
 firewalls, tunneling via SSH, and over Tor. The Syncthing instance that is
 behind the proxy is limited to outbound connections - it can not listen for
 incoming connections via the proxy. It is however possible to receive incoming
 connections via :ref:`relaying`.
+
+.. versionadded:: 2.0.15
+
+    Support for HTTP and HTTPS proxies via ``all_proxy``.
 
 There is no graphical configuration to enable proxy usage in Syncthing.
 Instead, an environment variable ``all_proxy`` must be set that points to the
@@ -21,6 +25,17 @@ Linux-like system::
   [monitor] 11:25:39 INFO: Starting syncthing
   ...
   [monitor] 11:25:40 INFO: Proxy settings detected
+
+Or for an HTTP/HTTPS proxy::
+
+  $ export all_proxy=http://10.20.30.40:8080
+  $ # Or with authentication and encryption
+  $ export all_proxy=https://user:password@proxy.example.com:8443
+  $ syncthing
+
+HTTP proxies requiring basic authentication can be specified by embedding
+credentials in the proxy URL. When credentials are used over a cleartext HTTP
+proxy, a warning will be logged.
 
 Note that this environment variable is *not* named with capital letters - it
 must be exactly ``all_proxy``. The "Proxy settings detected" log message
@@ -50,7 +65,12 @@ Caveats
 -------
 
 Syncthing will use the ``http_proxy`` / ``https_proxy`` settings in combination with
-``all_proxy``. Proxies specified with ``http_`` variants will be used behind the socks proxy.
+``all_proxy``. Proxies specified with ``http_`` variants will be used behind the
+configured proxy.
 
 If this is not desired, make sure to undefine the ``http_proxy`` / ``https_proxy``
 variables for syncthing.
+
+When using an HTTP proxy via ``all_proxy``, only outbound TCP connections are
+supported. Non-TCP transports and listening sockets are not supported through
+HTTP or HTTPS proxies.

--- a/users/proxying.rst
+++ b/users/proxying.rst
@@ -11,7 +11,7 @@ behind the proxy is limited to outbound connections - it can not listen for
 incoming connections via the proxy. It is however possible to receive incoming
 connections via :ref:`relaying`.
 
-.. versionadded:: 2.0.15
+.. versionadded:: 2.1.0
 
     Support for HTTP and HTTPS proxies via ``all_proxy``.
 


### PR DESCRIPTION
Update the proxying documentation to reflect support for HTTP and HTTPS proxies in addition to SOCKS5.

The documentation now describes:
- Use of http:// and https:// proxy URLs via the all_proxy environment variable
- Embedded basic authentication in proxy URLs
- A warning when credentials are sent over cleartext HTTP proxies
- Limitations of HTTP(S) proxies (outbound TCP only)

(related to https://github.com/syncthing/syncthing/pull/10572)