### PR TITLE
chore(releases): fix incorrect English tense

### DIFF
--- a/users/releases.rst
+++ b/users/releases.rst
@@ -8,7 +8,7 @@ Versions & Releases
 Major, Minor, or Patch
 ----------------------
 
-Since the 1.0.0 release, Syncthing uses a `semver
+Since the 1.0.0 release, Syncthing has used a `semver
 <https://semver.org/>`__-like [1]_ three part version number, **x.y.z** where *x*
 is the major version, *y* is the minor version, and *z* is the patch
 version. We decide the version number for a new release based on the


### PR DESCRIPTION
My attempt to explain the proposed change, in case that is helpful:

Expressions like "since _some event_" refers to a *span* of time that began at some point in the past and continues up until the present.  This is not compatible with the simple present tense, for reasons which are hard to explain but which I will *attempt* to explain.

The simple present tense in English is normally used for something recurring or ongoing.  ("I run" means I have a habit of running, not that I'm running at the moment.)  Since this action extends over time it might appear to be compatible with an expression using "since" (and also because many other languages use expressions just like that), but in English the simple present isn't compatible with "since _some event_", maybe because one expression has a stated beginning and the other does not, or maybe because it can be confused with expressions like "since _reason_"—for example "since it is cold, I wear gloves".