### PR TITLE
chore(releases): update minor version criterion

### DIFF
--- a/users/releases.rst
+++ b/users/releases.rst
@@ -18,9 +18,8 @@ following criteria:
   they cannot connect to each other or otherwise can't sync files for some
   reason? That's a new *major* version. (This hasn't happened yet.)
 
-- Are there changes in the REST API so that integrations or wrappers
-  need changes, or did the database schema or configuration change so that a
-  downgrade might be problematic? That's a new *minor* version.
+- Are there new features (commits with type ``feat``)? That's a new
+  *minor* version.
 
 - If there are no specific concerns as above, it's a new *patch* version.
 


### PR DESCRIPTION
For some time (since syncthing/syncthing@58c85fc9dbb8c56cd1cea70962b8f7bbb79e7329 I think), the minor version criterion hasn't been up to date.

For instance, v2.0.16-rc.1 contains a "configuration change so that a downgrade might be problematic", but is still a patch version.

I think the version number is automatically chosen based on commit type when pushing to `release` or `release-rc` branch.

https://github.com/syncthing/syncthing/blob/8c7c413f5cc6690865e4c9b5fabbe9227b52138c/script/next-version.go#L61-L73