### PR TITLE
docs(stignore): add pattern ordering note and common pitfalls section

### DIFF
--- a/users/ignoring.rst
+++ b/users/ignoring.rst
@@ -34,6 +34,16 @@ Patterns
 The ``.stignore`` file contains a list of file or path patterns. The
 *first* pattern that matches will decide the fate of a given file.
 
+.. note::
+
+   When you write a pattern like ``!/mydir``, Syncthing automatically
+   also unignores everything inside that directory (as if you also wrote
+   ``!/mydir/**``). This auto-expansion is placed immediately after the
+   original pattern. Keep this in mind when ordering patterns — if you
+   need to ignore specific paths *inside* an unignored directory, those
+   ignore rules must appear **before** the ``!/mydir`` line. See
+   `Common Pitfalls`_ below for a detailed example.
+
 -  Regular file names match themselves, i.e. the pattern ``foo`` matches
    the files ``foo``, ``subdir/foo`` as well as any directory named
    ``foo``. Spaces are treated as regular characters, except for leading
@@ -197,6 +207,53 @@ all files and directories called "foo", ending in a "2" or starting with
   ``some/directory/`` matches the content of the directory, but not the
   directory itself. If you want the pattern to match the directory and its
   content, make sure it does not have a ``/`` at the end of the pattern.
+
+Common Pitfalls
+---------------
+
+**Pattern ordering with whitelisted directories**
+
+A common use case is to sync only specific directories while ignoring
+everything else, but also excluding certain subdirectories (like ``.git``)
+within the whitelisted directories. Getting the pattern order right is
+critical.
+
+This does **not** work as expected::
+
+    // WRONG — .git contents are NOT ignored
+    !/myproject
+    !/myproject/**/.git/config
+    /myproject/**/.git/**
+    *
+
+The intent is to sync ``myproject`` but ignore ``.git`` directories
+(except ``config``). However, all ``.git`` contents are synced because
+``!/myproject`` auto-expands to also include ``!/myproject/**``, which
+matches everything under ``myproject/`` — including ``.git`` contents —
+before the ignore pattern ``/myproject/**/.git/**`` is ever reached.
+
+The correct ordering places specific ignore rules **before** the broad
+whitelist::
+
+    // CORRECT — .git contents are properly ignored
+    !/myproject/**/.git/config
+    /myproject/**/.git/**
+    !/myproject
+    *
+
+With this ordering:
+
+- ``myproject/repo/.git/config`` matches ``!/myproject/**/.git/config``
+  first → **synced**
+- ``myproject/repo/.git/objects/abc`` matches ``/myproject/**/.git/**``
+  first → **ignored**
+- ``myproject/repo/src/main.go`` matches the auto-expanded
+  ``!/myproject/**`` → **synced**
+- ``randomfile`` matches ``*`` → **ignored**
+
+**The rule:** when combining ``!/dir`` with ignore patterns for paths
+inside that directory, the specific ignore patterns must come **before**
+the ``!/dir`` whitelist line.
 
 .. versionadded:: 1.19.0
 


### PR DESCRIPTION
Consider merging this. It took me hours to figure out why my ignore patterns weren't working, and I was only able to understand the issue after analysing the actual source code. It's definitely up to you whether you want to accept this — I just thought it could help some future people who hit the same wall. And yes, both the text in this PR and the documentation changes are AI-generated, but believe me there is a human with intent behind it who verified everything before opening this PR.

## Summary

- Add a note in the Patterns section explaining that `!/dir` auto-expands to also unignore `!/dir/**`, and that this affects pattern ordering
- Add a new "Common Pitfalls" section with a practical `.git` example showing both incorrect and correct pattern ordering
- Cross-reference from the note to the new section

## Motivation

Users commonly write `.stignore` patterns in an intuitive but incorrect order — broad whitelist first (`!/mydir`), then specific exclusions after (`/mydir/**/.git/**`). This fails silently because Syncthing uses first-match-wins and auto-expands directory unignore patterns. The current documentation doesn't warn about this ordering requirement.

This is especially common when syncing home directories or project folders while trying to exclude `.git` internals, `node_modules`, etc.

## Changes

1. **Note after first-match-wins explanation** — alerts users early that `!/dir` creates an implicit `!/dir/**` and links to the pitfalls section
2. **Common Pitfalls section** — shows the wrong ordering, explains why it fails, shows the correct ordering, and walks through how each path is matched