### PR TITLE
docs: update advanced/device-numconnections for new default

### DIFF
--- a/advanced/device-numconnections.rst
+++ b/advanced/device-numconnections.rst
@@ -15,12 +15,12 @@ A simple form of negotiation is used to decide how many connections to use
 between a device pair. It goes like this:
 
 - If either side is configured to use a single connection, then a single
-  connection is used. Since the default is to use a single connection this
-  means that to use more than one connection both sides must be configured
-  to do so.
+  connection is used. Since the default is to use multiple connections
+  (specifically three), this means that to use more than one connection both
+  sides must be configured to do so.
 - If both sides are configured to use multiple connections, then the larger
-  of the two values is used. That is, if one side is configured to use three
-  connections and the other is set to use eight connections, eight
+  of the two values is used. That is, if one side is left at the default of
+  three connections and the other is set to use eight connections, eight
   connections will be used.
 - A maximum of 128 connections will be used under all circumstances. It is
   likely that the "return on investment" in further connections is


### PR DESCRIPTION
As indicated in `lib/config/deviceconfiguration.go`, specifically `const defaultNumConnections = 3`, the default value went from 1→3 in 2.x.

The changes I propose are as follows:

(0) Make no changes to the introduction sentence:

"numConnections[...]. A zero value means to use the Syncthing default."

Referencing the specific default value of 3 here would be repetitive and would nullify the need to reference it in the sections below, where it serves a much greater purpose. At this point in the text the reader needs to know the default, not its exact value.

(1) Keep "single connection" section. While this section technically could have been removed since it is implied by the following one, users who have hardcoded the default value of 1, or users who want a counterpoint to the "maximum 128" section may still find it useful.

(2) Modify the "multiple connections" section to indicate the new default of 3, and highlight that it is now the new default in the comparison section, in a way that avoids redundancy with the previous section.

(3) Make no changes to "maximum 128" section.