### PR TITLE
chore: clarify database resetting options

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -92,7 +92,7 @@ version = release.partition('-')[0]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build', '_syncthing', 'draft', 'README.rst', 'users/faq-parts']
+exclude_patterns = ['_build', '_syncthing', 'draft', 'README.rst', 'users/faq-parts', 'includes']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/includes/cli-commands.rst
+++ b/includes/cli-commands.rst
@@ -24,8 +24,7 @@ errors
 
 debug
     Various tools to aid in diagnosing problems or collection information for
-    bug reports.  Some of these commands access the database directly and can
-    therefore only work when Syncthing is not running.
+    bug reports.
 
 ``-`` (a single dash)
     Reads subsequent commands from the standard input stream, without needing to

--- a/includes/debug-commands.rst
+++ b/includes/debug-commands.rst
@@ -1,0 +1,14 @@
+debug reset-database
+    Reset the database, forcing a full rescan and resync.  **Must only be used
+    when Syncthing is not running.**  More granular reset operations are
+    available on the REST API while Syncthing is running:
+    :doc:`../rest/system-reset-post`
+
+debug database-statistics
+    Display database size statistics.
+
+debug database-counts
+    Display database folder counts.
+
+debug database-file
+    Display database file metadata.

--- a/includes/debug-commands.rst
+++ b/includes/debug-commands.rst
@@ -1,3 +1,5 @@
+.. _reset-database:
+
 debug reset-database
     Reset the database, forcing a full rescan and resync.  **Must only be used
     when Syncthing is not running.**  More granular reset operations are

--- a/rest/system-reset-post.rst
+++ b/rest/system-reset-post.rst
@@ -10,5 +10,7 @@ information for that folder will be erased:
 
         curl -X POST -H "X-API-Key: abc123" http://localhost:8384/rest/system/reset?folder=ab1c2-def3g
 
-**Caution**: See :option:`--reset-database` for ``.stfolder`` creation
-side-effect and caution regarding mountpoints.
+Creates ``.stfolder`` folders in each sync folder if they do not already exist.
+**Caution**: Ensure that all sync folders which are mountpoints are already
+mounted.  Inconsistent versions may result if the mountpoint is later mounted
+and contains older versions.

--- a/users/config.rst
+++ b/users/config.rst
@@ -1337,11 +1337,10 @@ The ``options`` element contains all other global configuration options.
 
 .. option:: options.sendFullIndexOnUpgrade
 
-    Controls whether all index data is resent when an upgrade has happened,
-    equivalent to starting Syncthing with :option:`--reset-deltas`.  This used
-    to be the default behavior in older versions, but is mainly useful as a
-    troubleshooting step and causes high database churn. The default is now
-    ``false``.
+    Controls whether all index data is resent when an upgrade has happened.
+    This used to be the default behavior in older versions, but is mainly useful
+    as a troubleshooting step and causes high database churn.  The default is
+    now ``false``.
 
 .. option:: options.featureFlag
     :aliases: options.featureFlags

--- a/users/syncthing.rst
+++ b/users/syncthing.rst
@@ -323,6 +323,14 @@ saves the hassle of handling HTTP connections and API authentication.
 
 .. include:: ../includes/cli-commands.rst
 
+For troubleshooting issues, the ``debug`` subcommand provides some commonly
+needed actions for data analysis and repair.  Some of these commands access the
+database directly and can therefore only work when Syncthing is not running.
+Not to be confused with the ``cli debug`` subcommand group, which works via the
+REST API.
+
+.. include:: ../includes/debug-commands.rst
+
 Proxies
 -------
 


### PR DESCRIPTION
The `--reset-deltas` and `--reset-database` options were removed in Syncthing v2.  Fix leftover references and in the process, document the current `syncthing debug ...` subcommand group, where `reset-database` now lives.

See individual commit messages for details.  The last one I'm not quite sure about.  I resurrected the removed text from the `--reset-database` option docs, but couldn't verify that the corresponding API endpoint actually does recreate `.stfolder` markers.  Maybe this behavior was also removed in v2?  I haven't dug deep enough to be sure.