### PR TITLE
fix: avoid warnings in custom config option extension

### DIFF
--- a/_ext/syncthing_config.py
+++ b/_ext/syncthing_config.py
@@ -117,7 +117,7 @@ class SyncthingConfigDomain(Domain):
 
     @property
     def config_sections(self) -> Set[str]:
-        return self.data.setdefault('sections', [])
+        return self.data.setdefault('sections', set())
 
     @property
     def config_options(self) -> Dict[str, Tuple]:

--- a/_ext/syncthing_config.py
+++ b/_ext/syncthing_config.py
@@ -168,6 +168,13 @@ class SyncthingConfigDomain(Domain):
             docname=self.env.docname,
             anchor=anchor, priority=0)
 
+    def clear_doc(self, docname: str):
+        self.data['options'] = {
+            signature: entry
+            for signature, entry in self.config_options.items()
+            if entry.docname != docname
+        }
+
 
 def setup(app):
     """Install the plugin.

--- a/_ext/syncthing_config.py
+++ b/_ext/syncthing_config.py
@@ -4,7 +4,7 @@ Sphinx extension to provide link anchors for configuration options.
 Modeled after the standard :directive:`cmdoption` directive.
 """
 
-from typing import Tuple, Dict, Iterator, Set, NamedTuple
+from typing import Any, Tuple, Dict, Iterator, Set, NamedTuple
 
 from docutils.nodes import Element
 from docutils.parsers.rst import directives
@@ -175,6 +175,19 @@ class SyncthingConfigDomain(Domain):
             if entry.docname != docname
         }
 
+    def merge_domaindata(self, docnames: Set[str], otherdata: Dict[str, Any]):
+        self.config_sections.update(otherdata.get('sections', set()))
+
+        for signature, entry in otherdata.get('options', {}).items():
+            if entry.docname in docnames:
+                if signature in self.config_options:
+                    other = self.config_options[signature]
+                    logger.warning(
+                        'Duplicate object description of %s, other instance in %s',
+                        entry.name, other.docname
+                    )
+                self.config_options[signature] = entry
+
 
 def setup(app):
     """Install the plugin.
@@ -182,4 +195,7 @@ def setup(app):
     :param app: Sphinx application context.
     """
     app.add_domain(SyncthingConfigDomain)
-    return
+    return {
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/_ext/syncthing_config.py
+++ b/_ext/syncthing_config.py
@@ -4,10 +4,11 @@ Sphinx extension to provide link anchors for configuration options.
 Modeled after the standard :directive:`cmdoption` directive.
 """
 
-from typing import Any, Tuple, Dict, Iterator, Set, NamedTuple
+from typing import Any, Iterator, NamedTuple, Tuple
 
 from docutils.nodes import Element
 from docutils.parsers.rst import directives
+
 from sphinx import addnodes
 from sphinx.addnodes import pending_xref
 from sphinx.builders import Builder
@@ -15,8 +16,8 @@ from sphinx.directives import ObjectDescription
 from sphinx.domains import Domain, ObjType
 from sphinx.environment import BuildEnvironment
 from sphinx.roles import XRefRole
-from sphinx.util.nodes import make_refnode
 from sphinx.util import logging
+from sphinx.util.nodes import make_refnode
 
 
 __licence__ = 'BSD (3 clause)'
@@ -116,11 +117,11 @@ class SyncthingConfigDomain(Domain):
     }
 
     @property
-    def config_sections(self) -> Set[str]:
+    def config_sections(self) -> set[str]:
         return self.data.setdefault('sections', set())
 
     @property
-    def config_options(self) -> Dict[str, Tuple]:
+    def config_options(self) -> dict[str, Tuple]:
         return self.data.setdefault('options', {})  # fullname -> (docname, node_id)
 
     def get_full_qualified_name(self, node):  # FIXME: what is this for?!
@@ -175,7 +176,7 @@ class SyncthingConfigDomain(Domain):
             if entry.docname != docname
         }
 
-    def merge_domaindata(self, docnames: Set[str], otherdata: Dict[str, Any]):
+    def merge_domaindata(self, docnames: set[str], otherdata: dict[str, Any]):
         self.config_sections.update(otherdata.get('sections', set()))
 
         for signature, entry in otherdata.get('options', {}).items():


### PR DESCRIPTION
The custom extension for implementing special config option directives in Sphinx has always caused lots of warnings for incremental rebuilds and was not safe for parallel builds.  Implement two additional Domain methods to fix both issues.  Fix some minor quirks and linter warnings for modern Python versions (3.9 is end-of-life already and was the first to support some newer syntax).

Some more details in individual commit messages.