### PR TITLE
chore: cleanup obsolete Transifex mention

### DIFF
--- a/dev/intro.rst
+++ b/dev/intro.rst
@@ -147,11 +147,8 @@ script/
    genassets/
       Generates asset files that are compiled into ``syncthing`` as part of the build process (build utility).
 
-   transifexdl/
-      Downloads translations from Transifex (build utility).
-
    translate/
-      Generates translation source for Transifex based on the HTML source (build utility).
+      Generates translation source based on the HTML source (build utility).
 
 test/
    The integration test suite.

--- a/dev/intro.rst
+++ b/dev/intro.rst
@@ -144,10 +144,10 @@ man/
 script/
    Various utility scripts for auto generating stuff and so on.
 
-   genassets/
+   genassets.go
       Generates asset files that are compiled into ``syncthing`` as part of the build process (build utility).
 
-   translate/
+   translate.go
       Generates translation source based on the HTML source (build utility).
 
 test/


### PR DESCRIPTION
Update developer intro to skip Transifex reference.  Fix script names where a directory was supposedly documented.