### PR TITLE
docs: resolve minor spelling and grammar typos in config and tuning

### DIFF
--- a/users/config.rst
+++ b/users/config.rst
@@ -1169,7 +1169,7 @@ The ``options`` element contains all other global configuration options.
 .. option:: options.urAccepted
 
     Whether the user has accepted to submit anonymous usage data. The default,
-    ``0``, mean the user has not made a choice, and Syncthing will ask at some
+    ``0``, means the user has not made a choice, and Syncthing will ask at some
     point in the future. ``-1`` means no, a number above zero means that that
     version of usage reporting has been accepted.
 

--- a/users/tuning.rst
+++ b/users/tuning.rst
@@ -50,7 +50,7 @@ These options are folder specific and should be set on each folder:
 - :opt:`copiers`
     The number of routines used for the copy stage of file syncing. Similar
     to other concurrency options, if there are a lot of files to sync and if
-    the I/O system can handle it it you may see increased performance by
+    the I/O system can handle it, you may see increased performance by
     increasing this value. The default is system dependent, somewhere
     between 1 and the number of CPU cores available.
 

--- a/users/versioning.rst
+++ b/users/versioning.rst
@@ -242,7 +242,7 @@ more consistent with how the Explorer works.
     Add-Type -AssemblyName Microsoft.VisualBasic
 
     # We need to test if a Syncthing .tmp file exists. If it does, we assume
-    # a modification and delete the existing file. If if does not, we assume
+    # a modification and delete the existing file. If it does not, we assume
     # a deletion and recycle the current file. If succeeded, we also include
     # the deleted/recycled file in the Syncthing's DEBUG output.
     if (Test-Path -LiteralPath ((Split-Path -Path $args) + "\~syncthing~" + (Split-Path -Path $args -Leaf) + ".tmp")) {


### PR DESCRIPTION
```markdown
### Description
This pull request corrects two minor spelling and grammatical typos in the documentation. Fixing these typos keeps the documentation clean, professional, and easy to read.

### Changes
| File | Line | Original text | Corrected text | Description |
| :--- | :--- | :--- | :--- | :--- |
| `users/config.rst` | 1172 | `mean` | `means` | Subject-verb agreement correction |
| `users/tuning.rst` | 53 | `handle it it you` | `handle it, you` | Duplicate word correction |

### Checklist
- [x] Typos are verified against the surrounding context.
- [x] All modifications are limited only to documentation (RST files).
```