### PR TITLE
fix: document uppercase ALL_PROXY support

### DIFF
--- a/users/proxying.rst
+++ b/users/proxying.rst
@@ -37,9 +37,9 @@ HTTP proxies requiring basic authentication can be specified by embedding
 credentials in the proxy URL. When credentials are used over a cleartext HTTP
 proxy, a warning will be logged.
 
-Note that this environment variable is *not* named with capital letters - it
-must be exactly ``all_proxy``. The "Proxy settings detected" log message
-indicates that Syncthing is using the proxy configuration.
+Both the uppercase ``ALL_PROXY`` and lowercase ``all_proxy`` spellings are
+supported. If both are set, ``ALL_PROXY`` takes precedence. The "Proxy settings
+detected" log message indicates that Syncthing is using the proxy configuration.
 
 Disabling Fallback
 ------------------

--- a/users/syncthing.rst
+++ b/users/syncthing.rst
@@ -337,11 +337,10 @@ Proxies
 Syncthing can use a SOCKS, HTTP, or HTTPS proxy to talk to the outside
 world. The proxy is used for outgoing connections only - it is not possible
 to accept incoming connections through the proxy. The proxy is configured
-through the environment variable ``all_proxy``. Somewhat unusually, this
-variable must be named in lower case - it is not ":strike:`ALL_PROXY`". For
-example::
+through the environment variable ``ALL_PROXY`` or its lowercase variant
+``all_proxy``. If both are set, ``ALL_PROXY`` takes precedence. For example::
 
-    $ export all_proxy=socks://192.0.2.42:8081
+    $ export ALL_PROXY=socks://192.0.2.42:8081
 
 Development Settings
 --------------------


### PR DESCRIPTION
Syncthing’s proxy documentation incorrectly states that only lowercase `all_proxy` is supported. `golang.org/x/net/proxy` accepts both `ALL_PROXY` and `all_proxy`, with the uppercase form taking precedence and thus being preferred.

This corrects both affected documentation passages while leaving the existing examples unchanged. Uppercase support was added in [golang/net commit 054b33e](https://github.com/golang/net/commit/054b33e6527139ad5b1ec2f6232c3b175bd9a30c) and subsequently shipped by Syncthing.